### PR TITLE
Segeo UI variable

### DIFF
--- a/fluent/src/androidMain/kotlin/com/konyaco/fluent/defaultFontFamily.android.kt
+++ b/fluent/src/androidMain/kotlin/com/konyaco/fluent/defaultFontFamily.android.kt
@@ -1,0 +1,9 @@
+package com.konyaco.fluent
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontFamily
+
+@Composable
+actual fun defaultFontFamily(): FontFamily? {
+    return null
+}

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/DefaultFontFamily.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/DefaultFontFamily.kt
@@ -1,0 +1,7 @@
+package com.konyaco.fluent
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontFamily
+
+@Composable
+expect fun defaultFontFamily(): FontFamily?

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/FluentTheme.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/FluentTheme.kt
@@ -5,16 +5,29 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
 
 @Composable
 fun FluentTheme(
     colors: Colors = FluentTheme.colors,
     typography: Typography = FluentTheme.typography,
+    defaultFontFamily: FontFamily? = defaultFontFamily(),
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(
         LocalColors provides colors,
-        LocalTypography provides typography,
+        LocalTypography provides (defaultFontFamily?.let {
+            Typography(
+                caption = typography.caption.copy(fontFamily = defaultFontFamily),
+                body = typography.body.copy(fontFamily = defaultFontFamily),
+                bodyStrong = typography.bodyStrong.copy(fontFamily = defaultFontFamily),
+                bodyLarge = typography.bodyLarge.copy(fontFamily = defaultFontFamily),
+                subtitle = typography.subtitle.copy(fontFamily = defaultFontFamily),
+                title = typography.title.copy(fontFamily = defaultFontFamily),
+                titleLarge = typography.titleLarge.copy(fontFamily = defaultFontFamily),
+                display = typography.display.copy(fontFamily = defaultFontFamily),
+            )
+        } ?: typography),
         content = content
     )
 }

--- a/fluent/src/jvmMain/kotlin/com/konyaco/fluent/defaultFontFamily.desktop.kt
+++ b/fluent/src/jvmMain/kotlin/com/konyaco/fluent/defaultFontFamily.desktop.kt
@@ -1,0 +1,20 @@
+package com.konyaco.fluent
+
+import androidx.compose.runtime.*
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.toFontFamily
+import androidx.compose.ui.text.platform.Font
+import org.jetbrains.skiko.AwtFontManager
+
+@Composable
+actual fun defaultFontFamily(): FontFamily? {
+    val state = remember {
+        mutableStateOf<FontFamily?>(null)
+    }
+    LaunchedEffect(state) {
+        state.value = AwtFontManager.DEFAULT.findFontFamilyFile("Segoe UI Variable")?.let {
+            Font(it).toFontFamily()
+        }
+    }
+    return state.value
+}


### PR DESCRIPTION
Load Segeo UI Variable Font as the defaultFontFamily when desktop system contain the font. which make control more consistent with Windows 11.
Screenshot
![image](https://user-images.githubusercontent.com/26089739/233684047-1b680519-8c64-47c1-9644-c847de4039a6.png)
