### PR TITLE
[fluent] style migration: visual state scheme migration

### DIFF
--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Button.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Button.kt
@@ -55,7 +55,7 @@ import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
 import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.ChevronDown
-import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.PentaVisualScheme
 import com.konyaco.fluent.scheme.VisualState
 import com.konyaco.fluent.scheme.VisualStateScheme
 import com.konyaco.fluent.scheme.collectVisualState
@@ -68,7 +68,7 @@ import kotlinx.coroutines.launch
 )
 typealias ButtonColors = ButtonColorScheme
 
-typealias ButtonColorScheme = ValueVisualStateScheme<ButtonColor>
+typealias ButtonColorScheme = PentaVisualScheme<ButtonColor>
 
 @Immutable
 data class ButtonColor(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Button.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Button.kt
@@ -58,7 +58,7 @@ import com.konyaco.fluent.icons.regular.ChevronDown
 import com.konyaco.fluent.scheme.ValueVisualStateScheme
 import com.konyaco.fluent.scheme.VisualState
 import com.konyaco.fluent.scheme.VisualStateScheme
-import com.konyaco.fluent.scheme.collectCurrentScheme
+import com.konyaco.fluent.scheme.collectVisualState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -444,7 +444,7 @@ private fun ButtonLayer(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    val buttonColor = buttonColors.collectCurrentScheme(interaction, disabled)
+    val buttonColor = buttonColors.schemeFor(interaction.collectVisualState(disabled))
 
     val fillColor by animateColorAsState(
         buttonColor.fillColor,

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Button.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Button.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,6 +25,7 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,16 +55,20 @@ import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
 import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.ChevronDown
+import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.VisualState
+import com.konyaco.fluent.scheme.VisualStateScheme
+import com.konyaco.fluent.scheme.collectCurrentScheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-@Immutable
-data class ButtonColors(
-    val default: ButtonColor,
-    val hovered: ButtonColor,
-    val pressed: ButtonColor,
-    val disabled: ButtonColor
+@Deprecated(
+    message = "use ButtonColorScheme instead.",
+    replaceWith = ReplaceWith("ButtonColorScheme", imports = arrayOf("com.konyaco.fluent.component.ButtonColorScheme"))
 )
+typealias ButtonColors = ButtonColorScheme
+
+typealias ButtonColorScheme = ValueVisualStateScheme<ButtonColor>
 
 @Immutable
 data class ButtonColor(
@@ -78,7 +82,7 @@ fun Button(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     disabled: Boolean = false,
-    buttonColors: ButtonColors = buttonColors(),
+    buttonColors: VisualStateScheme<ButtonColor> = ButtonDefaults.buttonColors(),
     interaction: MutableInteractionSource = remember { MutableInteractionSource() },
     iconOnly: Boolean = false,
     content: @Composable RowScope.() -> Unit
@@ -91,7 +95,7 @@ fun AccentButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     disabled: Boolean = false,
-    buttonColors: ButtonColors = accentButtonColors(),
+    buttonColors: VisualStateScheme<ButtonColor> = ButtonDefaults.accentButtonColors(),
     interaction: MutableInteractionSource = remember { MutableInteractionSource() },
     iconOnly: Boolean = false,
     content: @Composable RowScope.() -> Unit
@@ -104,7 +108,7 @@ fun SubtleButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     disabled: Boolean = false,
-    buttonColors: ButtonColors = subtleButtonColors(),
+    buttonColors: VisualStateScheme<ButtonColor> = ButtonDefaults.subtleButtonColors(),
     interaction: MutableInteractionSource = remember { MutableInteractionSource() },
     iconOnly: Boolean = false,
     content: @Composable RowScope.() -> Unit
@@ -117,7 +121,7 @@ fun HyperlinkButton(
     navigateUri: String,
     modifier: Modifier = Modifier,
     disabled: Boolean = false,
-    buttonColors: ButtonColors = hyperlinkButtonColors(),
+    buttonColors: VisualStateScheme<ButtonColor> = ButtonDefaults.hyperlinkButtonColors(),
     interaction: MutableInteractionSource = remember { MutableInteractionSource() },
     iconOnly: Boolean = false,
     content: @Composable RowScope.() -> Unit
@@ -139,7 +143,7 @@ fun HyperlinkButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     disabled: Boolean = false,
-    buttonColors: ButtonColors = hyperlinkButtonColors(),
+    buttonColors: VisualStateScheme<ButtonColor> = ButtonDefaults.hyperlinkButtonColors(),
     interaction: MutableInteractionSource = remember { MutableInteractionSource() },
     iconOnly: Boolean = false,
     content: @Composable RowScope.() -> Unit
@@ -164,7 +168,7 @@ fun RepeatButton(
     delay: Long = 200,
     interval: Long = 50,
     disabled: Boolean = false,
-    buttonColors: ButtonColors = buttonColors(),
+    buttonColors: VisualStateScheme<ButtonColor> = ButtonDefaults.buttonColors(),
     interaction: MutableInteractionSource = remember { MutableInteractionSource() },
     iconOnly: Boolean = false,
     content: @Composable RowScope.() -> Unit
@@ -208,7 +212,7 @@ fun DropDownButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     disabled: Boolean = false,
-    buttonColors: ButtonColors = buttonColors(),
+    buttonColors: VisualStateScheme<ButtonColor> = ButtonDefaults.buttonColors(),
     interaction: MutableInteractionSource = remember { MutableInteractionSource() },
     iconOnly: Boolean = false,
     content: @Composable RowScope.() -> Unit
@@ -232,8 +236,11 @@ fun ToggleButton(
     onCheckedChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     disabled: Boolean = false,
-    colors: ButtonColors = buttonColors(),
-    selectedColors: ButtonColors = accentButtonColors(),
+    colors: VisualStateScheme<ButtonColor> = if(checked) {
+        ButtonDefaults.accentButtonColors()
+    } else {
+        ButtonDefaults.buttonColors()
+    },
     interaction: MutableInteractionSource = remember { MutableInteractionSource() },
     iconOnly: Boolean = false,
     outsideBorder: Boolean = !checked,
@@ -249,7 +256,7 @@ fun ToggleButton(
             role = Role.Checkbox
         ),
         iconOnly = iconOnly,
-        buttonColors = if (checked) selectedColors else colors,
+        buttonColors = colors,
         interaction = interaction,
         disabled = disabled,
         accentButton = !outsideBorder,
@@ -262,15 +269,15 @@ fun SplitButton(
     flyoutClick: () -> Unit,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    buttonColors: ButtonColors = buttonColors(),
+    buttonColors: VisualStateScheme<ButtonColor> = ButtonDefaults.buttonColors(),
     accentButton: Boolean = false,
     disabled: Boolean = false,
     content: @Composable RowScope.() -> Unit
 ) {
     val currentColor = if (!disabled) {
-        buttonColors.default
+        buttonColors.schemeFor(VisualState.Default)
     } else {
-        buttonColors.disabled
+        buttonColors.schemeFor(VisualState.Disabled)
     }
     val borderBrush = currentColor.borderBrush
     val endContentOffset = remember { mutableStateOf(0f) }
@@ -353,8 +360,11 @@ fun ToggleSplitButton(
     onClick: () -> Unit,
     checked: Boolean,
     modifier: Modifier = Modifier,
-    colors: ButtonColors = buttonColors(),
-    selectedColors: ButtonColors = accentButtonColors(),
+    colors: VisualStateScheme<ButtonColor> = if(checked) {
+        ButtonDefaults.accentButtonColors()
+    } else {
+        ButtonDefaults.buttonColors()
+    },
     accentButton: Boolean = checked,
     disabled: Boolean = false,
     content: @Composable RowScope.() -> Unit
@@ -363,7 +373,7 @@ fun ToggleSplitButton(
         flyoutClick = flyoutClick,
         onClick = onClick,
         modifier = modifier,
-        buttonColors = if (checked) selectedColors else colors,
+        buttonColors = colors,
         accentButton = accentButton,
         disabled = disabled,
         content = content
@@ -375,7 +385,7 @@ private fun Button(
     modifier: Modifier,
     interaction: MutableInteractionSource,
     disabled: Boolean,
-    buttonColors: ButtonColors,
+    buttonColors: VisualStateScheme<ButtonColor>,
     accentButton: Boolean,
     onClick: (() -> Unit)?,
     iconOnly: Boolean,
@@ -426,7 +436,7 @@ common interaction layer for button and split button.
 @Composable
 private fun ButtonLayer(
     shape: Shape,
-    buttonColors: ButtonColors,
+    buttonColors: VisualStateScheme<ButtonColor>,
     interaction: MutableInteractionSource,
     disabled: Boolean,
     accentButton: Boolean,
@@ -434,15 +444,7 @@ private fun ButtonLayer(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    val hovered by interaction.collectIsHoveredAsState()
-    val pressed by interaction.collectIsPressedAsState()
-
-    val buttonColor = when {
-        disabled -> buttonColors.disabled
-        pressed -> buttonColors.pressed
-        hovered -> buttonColors.hovered
-        else -> buttonColors.default
-    }
+    val buttonColor = buttonColors.collectCurrentScheme(interaction, disabled)
 
     val fillColor by animateColorAsState(
         buttonColor.fillColor,
@@ -464,121 +466,114 @@ private fun ButtonLayer(
     )
 }
 
-@Composable
-private fun buttonColors(): ButtonColors {
-    val colors = FluentTheme.colors
+object ButtonDefaults {
 
-    return remember(colors) {
-        ButtonColors(
-            default = ButtonColor(
-                colors.control.default,
-                colors.text.text.primary,
-                colors.borders.control
-            ),
-            hovered = ButtonColor(
-                colors.control.secondary,
-                colors.text.text.primary,
-                colors.borders.control
-            ),
-            pressed = ButtonColor(
-                colors.control.tertiary,
-                colors.text.text.secondary,
-                SolidColor(colors.stroke.control.default)
-            ),
-            disabled = ButtonColor(
-                colors.control.disabled,
-                colors.text.text.disabled,
-                SolidColor(colors.stroke.control.default)
-            )
+    @Stable
+    @Composable
+    fun buttonColors(
+        default: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.control.default,
+            contentColor = FluentTheme.colors.text.text.primary,
+            borderBrush = FluentTheme.colors.borders.control
+        ),
+        hovered: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.control.secondary
+        ),
+        pressed: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.control.tertiary,
+            contentColor = FluentTheme.colors.text.text.secondary,
+            borderBrush = SolidColor(FluentTheme.colors.stroke.control.default)
+        ),
+        disabled: ButtonColor = pressed.copy(
+            fillColor = FluentTheme.colors.control.disabled,
+            contentColor = FluentTheme.colors.text.text.disabled,
         )
-    }
-}
+    ) = ButtonColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
 
-@Composable
-private fun accentButtonColors(): ButtonColors {
-    val colors = FluentTheme.colors
-    return remember(colors) {
-        ButtonColors(
-            default = ButtonColor(
-                colors.fillAccent.default,
-                colors.text.onAccent.primary,
-                colors.borders.accentControl
-            ),
-            hovered = ButtonColor(
-                colors.fillAccent.secondary,
-                colors.text.onAccent.primary,
-                colors.borders.accentControl
-            ),
-            pressed = ButtonColor(
-                colors.fillAccent.tertiary,
-                colors.text.onAccent.secondary,
-                SolidColor(colors.stroke.control.onAccentDefault)
-            ),
-            disabled = ButtonColor(
-                colors.fillAccent.disabled,
-                colors.text.onAccent.disabled,
-                SolidColor(Color.Transparent) // Disabled accent button does not have border
-            )
+    @Stable
+    @Composable
+    fun accentButtonColors(
+        default: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.fillAccent.default,
+            contentColor = FluentTheme.colors.text.onAccent.primary,
+            borderBrush = FluentTheme.colors.borders.accentControl
+        ),
+        hovered: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.secondary
+        ),
+        pressed: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.fillAccent.tertiary,
+            contentColor = FluentTheme.colors.text.onAccent.secondary,
+            borderBrush = SolidColor(FluentTheme.colors.stroke.control.onAccentDefault)
+        ),
+        disabled: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.fillAccent.disabled,
+            contentColor = FluentTheme.colors.text.onAccent.disabled,
+            borderBrush = SolidColor(Color.Transparent) // Disabled accent button does not have border
         )
-    }
-}
+    ) = ButtonColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
 
-@Composable
-private fun subtleButtonColors(): ButtonColors {
-    val colors = FluentTheme.colors
-    return remember(colors) {
-        ButtonColors(
-            default = ButtonColor(
-                colors.subtleFill.transparent,
-                colors.text.text.primary,
-                SolidColor(Color.Transparent)
-            ),
-            hovered = ButtonColor(
-                colors.subtleFill.secondary,
-                colors.text.text.primary,
-                SolidColor(Color.Transparent)
-            ),
-            pressed = ButtonColor(
-                colors.subtleFill.tertiary,
-                colors.text.text.secondary,
-                SolidColor(Color.Transparent)
-            ),
-            disabled = ButtonColor(
-                colors.subtleFill.disabled,
-                colors.text.text.disabled,
-                SolidColor(Color.Transparent)
-            ),
+    @Stable
+    @Composable
+    fun subtleButtonColors(
+        default: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.primary,
+            borderBrush = SolidColor(Color.Transparent)
+        ),
+        hovered: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.secondary,
+        ),
+        pressed: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.tertiary,
+            contentColor = FluentTheme.colors.text.text.secondary
+        ),
+        disabled: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.disabled,
+            contentColor = FluentTheme.colors.text.text.disabled
         )
-    }
-}
+    ) = ButtonColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled,
+    )
 
-@Composable
-private fun hyperlinkButtonColors(): ButtonColors {
-    val colors = FluentTheme.colors
-    return remember(colors) {
-        ButtonColors(
-            default = ButtonColor(
-                colors.subtleFill.transparent,
-                colors.text.accent.primary,
-                SolidColor(Color.Transparent)
-            ),
-            hovered = ButtonColor(
-                colors.subtleFill.secondary,
-                colors.text.accent.primary,
-                SolidColor(Color.Transparent)
-            ),
-            pressed = ButtonColor(
-                colors.subtleFill.tertiary,
-                colors.text.accent.secondary,
-                SolidColor(Color.Transparent)
-            ),
-            disabled = ButtonColor(
-                colors.subtleFill.disabled,
-                colors.text.accent.disabled,
-                SolidColor(Color.Transparent)
-            ),
+    @Stable
+    @Composable
+    fun hyperlinkButtonColors(
+        default: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.accent.primary,
+            borderBrush = SolidColor(Color.Transparent)
+        ),
+        hovered: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.secondary
+        ),
+        pressed: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.tertiary,
+            contentColor = FluentTheme.colors.text.accent.secondary,
+        ),
+        disabled: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.disabled,
+            contentColor = FluentTheme.colors.text.accent.disabled,
         )
-    }
+    ) = ButtonColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
 }
 
 @Composable

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/CheckBox.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/CheckBox.kt
@@ -33,7 +33,7 @@ import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
 import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.Checkmark
-import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.PentaVisualScheme
 import com.konyaco.fluent.scheme.VisualStateScheme
 import com.konyaco.fluent.scheme.collectVisualState
 
@@ -106,7 +106,7 @@ fun CheckBox(
     }
 }
 
-typealias CheckBoxColorScheme = ValueVisualStateScheme<CheckBoxColor>
+typealias CheckBoxColorScheme = PentaVisualScheme<CheckBoxColor>
 
 @Immutable
 data class CheckBoxColor(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/CheckBox.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/CheckBox.kt
@@ -7,8 +7,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,6 +17,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -33,6 +33,9 @@ import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
 import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.Checkmark
+import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.VisualStateScheme
+import com.konyaco.fluent.scheme.collectCurrentScheme
 
 @Composable
 fun CheckBox(
@@ -40,13 +43,16 @@ fun CheckBox(
     label: String? = null,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    colors: VisualStateScheme<CheckBoxColor> = if(checked) {
+        CheckBoxDefaults.selectedCheckBoxColors()
+    } else {
+        CheckBoxDefaults.defaultCheckBoxColors()
+    },
     onCheckStateChange: (checked: Boolean) -> Unit
 ) {
     // TODO: Animation, TripleStateCheckbox
     val interactionSource = remember { MutableInteractionSource() }
-    val hovered by interactionSource.collectIsHoveredAsState()
-    val pressed by interactionSource.collectIsPressedAsState()
-
+    val color = colors.collectCurrentScheme(interactionSource, !enabled)
     Row(
         modifier = modifier.then(
             if (label != null) Modifier.defaultMinSize(minWidth = 120.dp)
@@ -58,39 +64,15 @@ fun CheckBox(
         ) { onCheckStateChange(!checked) },
         verticalAlignment = Alignment.CenterVertically
     ) {
-        val colors = FluentTheme.colors
-        val fillColor by animateColorAsState(
-            if (checked) when {
-                !enabled -> colors.fillAccent.disabled
-                pressed -> colors.fillAccent.tertiary
-                hovered -> colors.fillAccent.secondary
-                else -> colors.fillAccent.default
-            } else when {
-                !enabled -> colors.controlAlt.disabled
-                pressed -> colors.controlAlt.quaternary
-                hovered -> colors.controlAlt.tertiary
-                else -> colors.controlAlt.secondary
-            },
+        val fillColor by animateColorAsState(color.fillColor,
             tween(FluentDuration.QuickDuration, easing = FluentEasing.FadeInFadeOutEasing)
         )
         Layer(
             modifier = Modifier.size(20.dp),
             shape = RoundedCornerShape(4.dp),
             color = fillColor,
-            contentColor = when {
-                !enabled -> colors.text.onAccent.disabled
-                pressed -> colors.text.onAccent.secondary
-                else -> colors.text.onAccent.primary
-            },
-            border = BorderStroke(
-                1.dp, if (checked) when {
-                    !enabled -> colors.fillAccent.disabled
-                    else -> Color.Transparent
-                } else when {
-                    !enabled -> colors.controlStrong.disabled
-                    else -> colors.controlStrong.default
-                }
-            ),
+            contentColor = color.contentColor,
+            border = BorderStroke(1.dp, color.borderColor),
             backgroundSizing = if (!checked) BackgroundSizing.InnerBorderEdge else BackgroundSizing.OuterBorderEdge
         ) {
             Box(contentAlignment = Alignment.CenterStart) {
@@ -118,8 +100,79 @@ fun CheckBox(
             Text(
                 modifier = Modifier.offset(y = (-1).dp),
                 text = it,
-                style = FluentTheme.typography.body.copy(color = colors.text.text.primary)
+                style = FluentTheme.typography.body.copy(color = color.labelTextColor)
             )
         }
     }
+}
+
+typealias CheckBoxColorScheme = ValueVisualStateScheme<CheckBoxColor>
+
+@Immutable
+data class CheckBoxColor(
+    val fillColor: Color,
+    val contentColor: Color,
+    val borderColor: Color,
+    val labelTextColor: Color
+)
+
+object CheckBoxDefaults {
+
+    @Stable
+    @Composable
+    fun defaultCheckBoxColors(
+        default: CheckBoxColor = CheckBoxColor(
+            fillColor = FluentTheme.colors.controlAlt.secondary,
+            contentColor = FluentTheme.colors.text.onAccent.primary,
+            borderColor = FluentTheme.colors.controlStrong.default,
+            labelTextColor = FluentTheme.colors.text.text.primary
+        ),
+        hovered: CheckBoxColor = default.copy(
+            fillColor = FluentTheme.colors.controlAlt.tertiary,
+        ),
+        pressed: CheckBoxColor = default.copy(
+            fillColor = FluentTheme.colors.controlAlt.quaternary,
+            contentColor = FluentTheme.colors.text.onAccent.secondary
+        ),
+        disabled: CheckBoxColor = CheckBoxColor(
+            fillColor = FluentTheme.colors.controlAlt.disabled,
+            contentColor = FluentTheme.colors.text.onAccent.disabled,
+            borderColor = FluentTheme.colors.controlStrong.disabled,
+            labelTextColor = FluentTheme.colors.text.text.primary
+        )
+    ) = CheckBoxColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+
+    @Stable
+    @Composable
+    fun selectedCheckBoxColors(
+        default: CheckBoxColor = CheckBoxColor(
+            fillColor = FluentTheme.colors.fillAccent.default,
+            contentColor = FluentTheme.colors.text.onAccent.primary,
+            borderColor = Color.Transparent,
+            labelTextColor = FluentTheme.colors.text.text.primary
+        ),
+        hovered: CheckBoxColor = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.secondary,
+        ),
+        pressed: CheckBoxColor = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.tertiary,
+            contentColor = FluentTheme.colors.text.onAccent.secondary
+        ),
+        disabled: CheckBoxColor = CheckBoxColor(
+            fillColor = FluentTheme.colors.fillAccent.disabled,
+            contentColor = FluentTheme.colors.text.onAccent.disabled,
+            borderColor = FluentTheme.colors.fillAccent.disabled,
+            labelTextColor = FluentTheme.colors.text.text.primary
+        )
+    ) = CheckBoxColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
 }

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/CheckBox.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/CheckBox.kt
@@ -35,7 +35,7 @@ import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.Checkmark
 import com.konyaco.fluent.scheme.ValueVisualStateScheme
 import com.konyaco.fluent.scheme.VisualStateScheme
-import com.konyaco.fluent.scheme.collectCurrentScheme
+import com.konyaco.fluent.scheme.collectVisualState
 
 @Composable
 fun CheckBox(
@@ -52,7 +52,7 @@ fun CheckBox(
 ) {
     // TODO: Animation, TripleStateCheckbox
     val interactionSource = remember { MutableInteractionSource() }
-    val color = colors.collectCurrentScheme(interactionSource, !enabled)
+    val color = colors.schemeFor(interactionSource.collectVisualState(!enabled))
     Row(
         modifier = modifier.then(
             if (label != null) Modifier.defaultMinSize(minWidth = 120.dp)

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuFlyout.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuFlyout.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -62,6 +61,9 @@ import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
 import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.ChevronRight
+import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.VisualStateScheme
+import com.konyaco.fluent.scheme.collectCurrentScheme
 import kotlinx.coroutines.delay
 
 @Composable
@@ -173,27 +175,19 @@ fun MenuFlyoutScope.MenuFlyoutItem(
     training: (@Composable () -> Unit)? = null,
     interaction: MutableInteractionSource? = null,
     enabled: Boolean = true,
-    colors: MenuColors = menuColors(),
+    colors: VisualStateScheme<MenuItemColor> = MenuFlyoutDefaults.defaultMenuItemColors(),
     paddingIcon: Boolean = false,
 ) {
     val actualInteraction = interaction ?: remember { MutableInteractionSource() }
-    val hovered by actualInteraction.collectIsHoveredAsState()
-    val pressed by actualInteraction.collectIsPressedAsState()
-
-    val menuColor = when {
-        !enabled -> colors.disabled
-        pressed -> colors.pressed
-        hovered -> colors.hovered
-        else -> colors.default
-    }
+    val color = colors.collectCurrentScheme(actualInteraction, !enabled)
 
     val fillColor by animateColorAsState(
-        menuColor.fillColor,
+        color.fillColor,
         animationSpec = tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
     )
 
     val contentColor by animateColorAsState(
-        menuColor.contentColor,
+        color.contentColor,
         animationSpec = tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
     )
     registerHoveredMenuItem(actualInteraction) {}
@@ -206,7 +200,7 @@ fun MenuFlyoutScope.MenuFlyoutItem(
         shape = RoundedCornerShape(size = 4.dp),
         color = fillColor,
         contentColor = contentColor,
-        border = BorderStroke(1.dp, menuColor.borderBrush),
+        border = BorderStroke(1.dp, color.borderBrush),
         backgroundSizing = BackgroundSizing.InnerBorderEdge
     ) {
         Row(
@@ -237,8 +231,8 @@ fun MenuFlyoutScope.MenuFlyoutItem(
                 text()
             }
             CompositionLocalProvider(
-                LocalContentColor provides menuColor.trainingColor,
-                LocalContentAlpha provides menuColor.trainingColor.alpha,
+                LocalContentColor provides color.trainingColor,
+                LocalContentAlpha provides color.trainingColor.alpha,
                 LocalTextStyle provides FluentTheme.typography.caption.copy(fontWeight = FontWeight.Normal)
             ) {
                 training?.invoke()
@@ -255,7 +249,7 @@ fun MenuFlyoutScope.MenuFlyoutItem(
     modifier: Modifier = Modifier,
     interaction: MutableInteractionSource? = null,
     enabled: Boolean = true,
-    colors: MenuColors = menuColors(),
+    colors: VisualStateScheme<MenuItemColor> = MenuFlyoutDefaults.defaultMenuItemColors(),
 ) {
     val paddingTop = with(LocalDensity.current) { flyoutPopPaddingFixShadowRender.roundToPx() }
     BasicFlyoutContainer(
@@ -328,53 +322,61 @@ private class MenuFlyoutScopeImpl : MenuFlyoutScope {
     }
 }
 
-@Immutable
-data class MenuColors(
-    val default: MenuColor,
-    val hovered: MenuColor,
-    val pressed: MenuColor,
-    val disabled: MenuColor
+@Deprecated(
+    message = "use MenuItemColorScheme instead",
+    replaceWith = ReplaceWith(
+        expression = "MenuItemColorScheme",
+        imports = arrayOf("com.konyaco.fluent.component.MenuItemColorScheme")
+    )
 )
+typealias MenuColors = MenuItemColorScheme
+typealias MenuItemColorScheme = ValueVisualStateScheme<MenuItemColor>
+
+@Deprecated(
+    message = "use MenuItemColor instead",
+    replaceWith = ReplaceWith("MenuItemColor", imports = arrayOf("com.konyaco.fluent.component.MenuItemColor"))
+)
+typealias MenuColor = MenuItemColor
 
 @Immutable
-data class MenuColor(
+data class MenuItemColor(
     val fillColor: Color,
     val contentColor: Color,
     val trainingColor: Color,
     val borderBrush: Brush
 )
 
-@Composable
-private fun menuColors(): MenuColors {
-    val colors = FluentTheme.colors
-    return remember(colors) {
-        MenuColors(
-            default = MenuColor(
-                colors.subtleFill.transparent,
-                colors.text.text.primary,
-                colors.text.text.primary.copy(0.6f),
-                SolidColor(Color.Transparent)
-            ),
-            hovered = MenuColor(
-                colors.subtleFill.secondary,
-                colors.text.text.primary,
-                colors.text.text.primary.copy(0.6f),
-                SolidColor(Color.Transparent)
-            ),
-            pressed = MenuColor(
-                colors.subtleFill.tertiary,
-                colors.text.text.secondary,
-                colors.text.text.secondary.copy(0.6f),
-                SolidColor(Color.Transparent)
-            ),
-            disabled = MenuColor(
-                colors.subtleFill.disabled,
-                colors.text.text.disabled,
-                colors.text.text.disabled,
-                SolidColor(Color.Transparent)
-            ),
+object MenuFlyoutDefaults {
+
+    @Composable
+    @Stable
+    fun defaultMenuItemColors(
+        default: MenuItemColor = MenuItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.primary,
+            trainingColor = FluentTheme.colors.text.text.primary.copy(0.6f),
+            borderBrush = SolidColor(Color.Transparent)
+        ),
+        hovered: MenuItemColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.secondary
+        ),
+        pressed: MenuItemColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.tertiary,
+            contentColor = FluentTheme.colors.text.text.secondary
+        ),
+        disabled: MenuItemColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.disabled,
+            contentColor = FluentTheme.colors.text.text.disabled,
+            trainingColor = FluentTheme.colors.text.text.disabled,
         )
-    }
+    ) = MenuItemColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+
+    //TODO Selected MenuItemColor
 }
 
 interface MenuFlyoutScope {

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuFlyout.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuFlyout.kt
@@ -61,7 +61,7 @@ import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
 import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.ChevronRight
-import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.PentaVisualScheme
 import com.konyaco.fluent.scheme.VisualStateScheme
 import com.konyaco.fluent.scheme.collectVisualState
 import kotlinx.coroutines.delay
@@ -330,7 +330,7 @@ private class MenuFlyoutScopeImpl : MenuFlyoutScope {
     )
 )
 typealias MenuColors = MenuItemColorScheme
-typealias MenuItemColorScheme = ValueVisualStateScheme<MenuItemColor>
+typealias MenuItemColorScheme = PentaVisualScheme<MenuItemColor>
 
 @Deprecated(
     message = "use MenuItemColor instead",

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuFlyout.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuFlyout.kt
@@ -63,7 +63,7 @@ import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.ChevronRight
 import com.konyaco.fluent.scheme.ValueVisualStateScheme
 import com.konyaco.fluent.scheme.VisualStateScheme
-import com.konyaco.fluent.scheme.collectCurrentScheme
+import com.konyaco.fluent.scheme.collectVisualState
 import kotlinx.coroutines.delay
 
 @Composable
@@ -179,7 +179,7 @@ fun MenuFlyoutScope.MenuFlyoutItem(
     paddingIcon: Boolean = false,
 ) {
     val actualInteraction = interaction ?: remember { MutableInteractionSource() }
-    val color = colors.collectCurrentScheme(actualInteraction, !enabled)
+    val color = colors.schemeFor(actualInteraction.collectVisualState(!enabled))
 
     val fillColor by animateColorAsState(
         color.fillColor,

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RadioButton.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RadioButton.kt
@@ -6,8 +6,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -17,16 +15,26 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.konyaco.fluent.FluentTheme
 import com.konyaco.fluent.animation.FluentDuration
 import com.konyaco.fluent.animation.FluentEasing
 import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
+import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.VisualStateScheme
+import com.konyaco.fluent.scheme.collectCurrentScheme
+import kotlin.math.roundToInt
 
 @Composable
 fun RadioButton(
@@ -35,12 +43,15 @@ fun RadioButton(
     modifier: Modifier = Modifier,
     label: String? = null,
     enabled: Boolean = true,
+    styles: VisualStateScheme<RadioButtonStyle> = if(selected) {
+        RadioButtonDefaults.selectedRadioButtonStyle()
+    } else {
+        RadioButtonDefaults.defaultRadioButtonStyle()
+    },
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     // TODO: Extract same logic
-    val hovered by interactionSource.collectIsHoveredAsState()
-    val pressed by interactionSource.collectIsPressedAsState()
-
+    val style = styles.collectCurrentScheme(interactionSource, !enabled)
     Row(modifier.then(
         if (label != null) Modifier.defaultMinSize(minWidth = 120.dp)
         else Modifier
@@ -48,17 +59,7 @@ fun RadioButton(
         onClick?.invoke()
     }) {
         val fillColor by animateColorAsState(
-            if (selected) when {
-                !enabled -> FluentTheme.colors.fillAccent.disabled
-                pressed -> FluentTheme.colors.fillAccent.tertiary
-                hovered -> FluentTheme.colors.fillAccent.secondary
-                else -> FluentTheme.colors.fillAccent.default
-            } else when {
-                !enabled -> FluentTheme.colors.controlAlt.disabled
-                pressed -> FluentTheme.colors.controlAlt.quaternary
-                hovered -> FluentTheme.colors.controlAlt.tertiary
-                else -> FluentTheme.colors.controlAlt.secondary
-            },
+            style.fillColor,
             tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
         )
         Layer(
@@ -67,38 +68,25 @@ fun RadioButton(
             color = fillColor,
             border = BorderStroke(
                 1.dp,
-                color = if (selected) when {
-                    !enabled -> FluentTheme.colors.fillAccent.disabled
-                    else -> FluentTheme.colors.fillAccent.default
-                } else when {
-                    !enabled || pressed -> FluentTheme.colors.stroke.controlStrong.disabled
-                    else -> FluentTheme.colors.stroke.controlStrong.default
-                }
+                style.borderColor
             ),
             backgroundSizing = BackgroundSizing.InnerBorderEdge
         ) {
-            Box(contentAlignment = Alignment.Center) {
+            Box(contentAlignment = FixedCenterAlignment) {
                 // Bullet, Only displays when selected, or is pressed
 
                 val size by animateDpAsState(
-                    if (selected) when {
-                        pressed -> 6.dp
-                        hovered -> 10.dp
-                        else -> 8.dp
-                    } else when {
-                        pressed -> 10.dp
-                        else -> 0.dp
-                    },
+                    style.dotSize,
                     tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
                 )
                 // Inner
                 Layer(
                     modifier = Modifier.size(if (size == 0.dp || !selected) size else size + 2.dp), // TODO: Remove this 2dp if outside border is provided
                     shape = CircleShape,
-                    color = FluentTheme.colors.text.onAccent.primary,
+                    color = style.dotColor,
                     border = if (selected) BorderStroke(
                         1.dp,
-                        FluentTheme.colors.borders.circle
+                        style.dotBorderBrush
                     ) else null,
                     backgroundSizing = BackgroundSizing.InnerBorderEdge,
                     content = {}
@@ -111,10 +99,92 @@ fun RadioButton(
                 modifier = Modifier.offset(y = (-1).dp),
                 text = it,
                 style = FluentTheme.typography.body.copy(
-                    color = if (enabled) FluentTheme.colors.text.text.primary
-                    else FluentTheme.colors.text.text.disabled
+                    color = style.labelColor
                 )
             )
         }
     }
+}
+
+typealias RadioButtonStyleScheme = ValueVisualStateScheme<RadioButtonStyle>
+
+@Immutable
+data class RadioButtonStyle(
+    val fillColor: Color,
+    val borderColor: Color,
+    val labelColor: Color,
+    val dotSize: Dp,
+    val dotColor: Color,
+    val dotBorderBrush: Brush
+)
+
+object RadioButtonDefaults {
+
+    @Stable
+    @Composable
+    fun defaultRadioButtonStyle(
+        default: RadioButtonStyle = RadioButtonStyle(
+            fillColor = FluentTheme.colors.controlAlt.secondary,
+            borderColor = FluentTheme.colors.stroke.controlStrong.default,
+            labelColor = FluentTheme.colors.text.text.primary,
+            dotSize = 0.dp,
+            dotColor = FluentTheme.colors.text.onAccent.primary,
+            dotBorderBrush = FluentTheme.colors.borders.circle
+        ),
+        hovered: RadioButtonStyle = default.copy(
+            fillColor = FluentTheme.colors.controlAlt.tertiary,
+        ),
+        pressed: RadioButtonStyle = default.copy(
+            fillColor = FluentTheme.colors.controlAlt.quaternary,
+            borderColor = FluentTheme.colors.stroke.controlStrong.disabled,
+            dotSize = 10.dp
+        ),
+        disabled: RadioButtonStyle = default.copy(
+            fillColor = FluentTheme.colors.controlAlt.disabled,
+            borderColor = FluentTheme.colors.stroke.controlStrong.disabled,
+            labelColor = FluentTheme.colors.text.text.disabled
+        )
+    ) = RadioButtonStyleScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+
+    @Stable
+    @Composable
+    fun selectedRadioButtonStyle(
+        default: RadioButtonStyle = RadioButtonStyle(
+            fillColor = FluentTheme.colors.fillAccent.default,
+            borderColor = FluentTheme.colors.fillAccent.default,
+            labelColor = FluentTheme.colors.text.text.primary,
+            dotSize = 8.dp,
+            dotColor = FluentTheme.colors.text.onAccent.primary,
+            dotBorderBrush = FluentTheme.colors.borders.circle
+        ),
+        hovered: RadioButtonStyle = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.secondary,
+            dotSize = 10.dp,
+        ),
+        pressed: RadioButtonStyle = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.tertiary,
+            dotSize = 6.dp
+        ),
+        disabled: RadioButtonStyle = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.disabled,
+            borderColor = FluentTheme.colors.fillAccent.disabled,
+            labelColor = FluentTheme.colors.text.text.disabled
+        )
+    ) = RadioButtonStyleScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+}
+
+private val FixedCenterAlignment = Alignment { size, space, _ ->
+    val centerX = (space.width - size.width).toFloat() / 2f
+    val centerY = (space.height - size.height).toFloat() / 2f
+    IntOffset(x = centerX.toInt(), y = centerY.roundToInt())
 }

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RadioButton.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RadioButton.kt
@@ -31,7 +31,7 @@ import com.konyaco.fluent.animation.FluentDuration
 import com.konyaco.fluent.animation.FluentEasing
 import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
-import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.PentaVisualScheme
 import com.konyaco.fluent.scheme.VisualStateScheme
 import com.konyaco.fluent.scheme.collectVisualState
 import kotlin.math.roundToInt
@@ -106,7 +106,7 @@ fun RadioButton(
     }
 }
 
-typealias RadioButtonStyleScheme = ValueVisualStateScheme<RadioButtonStyle>
+typealias RadioButtonStyleScheme = PentaVisualScheme<RadioButtonStyle>
 
 @Immutable
 data class RadioButtonStyle(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RadioButton.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RadioButton.kt
@@ -33,7 +33,7 @@ import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
 import com.konyaco.fluent.scheme.ValueVisualStateScheme
 import com.konyaco.fluent.scheme.VisualStateScheme
-import com.konyaco.fluent.scheme.collectCurrentScheme
+import com.konyaco.fluent.scheme.collectVisualState
 import kotlin.math.roundToInt
 
 @Composable
@@ -51,7 +51,7 @@ fun RadioButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     // TODO: Extract same logic
-    val style = styles.collectCurrentScheme(interactionSource, !enabled)
+    val style = styles.schemeFor(interactionSource.collectVisualState( !enabled))
     Row(modifier.then(
         if (label != null) Modifier.defaultMinSize(minWidth = 120.dp)
         else Modifier

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RatingControl.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RatingControl.kt
@@ -180,13 +180,7 @@ fun RatingControl(
     }
 }
 
-@Immutable
-data class RatingControlColorScheme(
-    override val default: RatingControlColor,
-    override val hovered: RatingControlColor,
-    override val pressed: RatingControlColor,
-    override val disabled: RatingControlColor,
-) : ValueVisualStateScheme<RatingControlColor>
+typealias RatingControlColorScheme = ValueVisualStateScheme<RatingControlColor>
 
 @Immutable
 data class RatingControlColor(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RatingControl.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RatingControl.kt
@@ -5,8 +5,21 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.layout.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -22,7 +35,10 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.*
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import com.konyaco.fluent.FluentTheme
 import com.konyaco.fluent.LocalContentColor
 import com.konyaco.fluent.ProvideTextStyle
@@ -31,7 +47,7 @@ import com.konyaco.fluent.icons.filled.Star
 import com.konyaco.fluent.icons.regular.Star
 import com.konyaco.fluent.scheme.ValueVisualStateScheme
 import com.konyaco.fluent.scheme.VisualStateScheme
-import com.konyaco.fluent.scheme.collectCurrentScheme
+import com.konyaco.fluent.scheme.collectVisualState
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterIsInstance
@@ -76,7 +92,7 @@ fun RatingControl(
             parseValueToFraction(itemPositions, if (displayPlaceholder.value) placeholderValueState() else valueState())
         }
     }
-    val color = colors.collectCurrentScheme(interactionSource, disabled)
+    val color = colors.schemeFor(interactionSource.collectVisualState(disabled))
     val hoveredOffset = remember { mutableStateOf<Offset?>(null) }
     /** collect pointer release offset */
     LaunchedEffect(interactionSource, value) {

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RatingControl.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/RatingControl.kt
@@ -45,7 +45,7 @@ import com.konyaco.fluent.ProvideTextStyle
 import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.filled.Star
 import com.konyaco.fluent.icons.regular.Star
-import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.PentaVisualScheme
 import com.konyaco.fluent.scheme.VisualStateScheme
 import com.konyaco.fluent.scheme.collectVisualState
 import kotlinx.coroutines.currentCoroutineContext
@@ -196,7 +196,7 @@ fun RatingControl(
     }
 }
 
-typealias RatingControlColorScheme = ValueVisualStateScheme<RatingControlColor>
+typealias RatingControlColorScheme = PentaVisualScheme<RatingControlColor>
 
 @Immutable
 data class RatingControlColor(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/SideNav.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/SideNav.kt
@@ -70,7 +70,7 @@ import com.konyaco.fluent.icons.regular.ChevronDown
 import com.konyaco.fluent.icons.regular.Navigation
 import com.konyaco.fluent.icons.regular.Search
 import com.konyaco.fluent.scheme.ValueVisualStateScheme
-import com.konyaco.fluent.scheme.collectCurrentScheme
+import com.konyaco.fluent.scheme.collectVisualState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -203,7 +203,7 @@ fun SideNavItem(
 ) {
     val interaction = remember { MutableInteractionSource() }
     //TODO Enabled
-    val color = colors.collectCurrentScheme(interaction)
+    val color = colors.schemeFor(interaction.collectVisualState(false))
     var currentPosition by remember {
         mutableStateOf(0f)
     }

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/SideNav.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/SideNav.kt
@@ -69,7 +69,7 @@ import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.ChevronDown
 import com.konyaco.fluent.icons.regular.Navigation
 import com.konyaco.fluent.icons.regular.Search
-import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.PentaVisualScheme
 import com.konyaco.fluent.scheme.collectVisualState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -315,7 +315,7 @@ fun SideNavItem(
     }
 }
 
-typealias NavigationItemColorScheme = ValueVisualStateScheme<NavigationItemColor>
+typealias NavigationItemColorScheme = PentaVisualScheme<NavigationItemColor>
 
 @Immutable
 data class NavigationItemColor(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/SideNav.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/SideNav.kt
@@ -16,8 +16,6 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,17 +36,22 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -66,6 +69,8 @@ import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.ChevronDown
 import com.konyaco.fluent.icons.regular.Navigation
 import com.konyaco.fluent.icons.regular.Search
+import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.collectCurrentScheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -184,21 +189,21 @@ fun SideNavItem(
     onClick: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     expandItems: Boolean = false,
+    colors: NavigationItemColorScheme = if (selected) {
+        NavigationDefaults.selectedSideNavigationItemColors()
+    } else {
+        NavigationDefaults.defaultSideNavigationItemColors()
+    },
     icon: @Composable (() -> Unit)? = null,
     items: @Composable (ColumnScope.() -> Unit)? = null,
+    indicator: @Composable IndicatorScope.() -> Unit = {
+        NavigationDefaults.VerticalIndicator(modifier = Modifier.indicatorOffset { selected })
+    },
     content: @Composable RowScope.() -> Unit
 ) {
     val interaction = remember { MutableInteractionSource() }
-    val hovered by interaction.collectIsHoveredAsState()
-    val pressed by interaction.collectIsPressedAsState()
-
-    val color = when {
-        selected && hovered -> FluentTheme.colors.subtleFill.tertiary
-        selected -> FluentTheme.colors.subtleFill.secondary
-        pressed -> FluentTheme.colors.subtleFill.tertiary
-        hovered -> FluentTheme.colors.subtleFill.secondary
-        else -> FluentTheme.colors.subtleFill.transparent
-    }
+    //TODO Enabled
+    val color = colors.collectCurrentScheme(interaction)
     var currentPosition by remember {
         mutableStateOf(0f)
     }
@@ -219,9 +224,9 @@ fun SideNavItem(
                 modifier = Modifier.fillMaxWidth().height(36.dp),
                 shape = RoundedCornerShape(size = 4.dp),
                 color = animateColorAsState(
-                    color, tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
+                    color.fillColor, tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
                 ).value,
-                contentColor = FluentTheme.colors.text.text.primary,
+                contentColor = color.contentColor,
                 border = null,
                 backgroundSizing = BackgroundSizing.OuterBorderEdge
             ) {
@@ -278,7 +283,9 @@ fun SideNavItem(
                     }
                 }
             }
-            Indicator(Modifier.align(Alignment.CenterStart).padding(start = navigationLevelPadding), selected)
+            Box(modifier = Modifier.align(Alignment.CenterStart).padding(start = navigationLevelPadding)) {
+                SideNavigationIndicatorScope.indicator()
+            }
         }
 
         if (items != null) {
@@ -308,9 +315,117 @@ fun SideNavItem(
     }
 }
 
+typealias NavigationItemColorScheme = ValueVisualStateScheme<NavigationItemColor>
+
+@Immutable
+data class NavigationItemColor(
+    val fillColor: Color,
+    val contentColor: Color
+)
+
+//TODO Common Defaults for SideNavigation and TopNavigation
+object NavigationDefaults {
+
+    @Composable
+    @Stable
+    fun defaultSideNavigationItemColors(
+        default: NavigationItemColor = NavigationItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.primary
+        ),
+        hovered: NavigationItemColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.secondary
+        ),
+        pressed: NavigationItemColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.tertiary
+        ),
+        //TODO Disabled style
+        disabled: NavigationItemColor = default
+    ) = NavigationItemColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+
+    @Composable
+    @Stable
+    fun selectedSideNavigationItemColors(
+        default: NavigationItemColor = NavigationItemColor(
+            fillColor = FluentTheme.colors.subtleFill.secondary,
+            contentColor = FluentTheme.colors.text.text.primary
+        ),
+        hovered: NavigationItemColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.tertiary
+        ),
+        pressed: NavigationItemColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.tertiary
+        ),
+        //TODO Disabled style
+        disabled: NavigationItemColor = default
+    ) = NavigationItemColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+
+    @Composable
+    fun VerticalIndicator(
+        modifier: Modifier = Modifier,
+        color: Color = FluentTheme.colors.fillAccent.default,
+        shape: Shape = CircleShape,
+        thickness: Dp = 3.dp
+    ) {
+        Box(modifier.width(thickness).background(color, shape))
+    }
+
+    //TODO TopNavigation
+    @Composable
+    fun HorizontalIndicator(
+        modifier: Modifier = Modifier,
+        color: Color = FluentTheme.colors.fillAccent.default,
+        shape: Shape = CircleShape,
+        thickness: Dp = 3.dp
+    ) {
+        Box(modifier.height(thickness).background(color, shape))
+    }
+
+}
+
+interface IndicatorScope {
+
+    @Composable
+    fun Modifier.indicatorOffset(visible: () -> Boolean): Modifier
+}
+
 interface AutoSuggestionBoxScope {
     fun Modifier.focusHandle(): Modifier
 }
+
+private object SideNavigationIndicatorScope: IndicatorScope {
+
+    @Composable
+    override fun Modifier.indicatorOffset(visible: () -> Boolean): Modifier {
+        val display by rememberUpdatedState(visible)
+        val selectionState = LocalSelectedItemPosition.current
+        val indicatorState = remember {
+            MutableTransitionState(display())
+        }
+        indicatorState.targetState = display()
+        val animationModifier = if (selectionState != null) {
+            Modifier.indicatorOffsetAnimation(16.dp, indicatorState, selectionState)
+        } else {
+            val height by updateTransition(display()).animateDp(transitionSpec = {
+                if (targetState) tween(FluentDuration.ShortDuration, easing = FluentEasing.FastInvokeEasing)
+                else tween(FluentDuration.QuickDuration, easing = FluentEasing.SoftDismissEasing)
+            }, targetValueByState = { if (it) 16.dp else 0.dp })
+            Modifier.height(height)
+        }
+        return then(animationModifier)
+    }
+}
+//TODO TopNavigationIndicatorScope
 
 internal class AutoSuggestionBoxScopeImpl(
     private val focusRequest: FocusRequester
@@ -321,7 +436,8 @@ internal class AutoSuggestionBoxScopeImpl(
 @Composable
 fun NavigationItemSeparator(
     isVertical: Boolean = false,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    color: Color = FluentTheme.colors.stroke.surface.default.copy(0.2f)
 ) {
     val sizeModifier = if (!isVertical) {
         Modifier.fillMaxWidth().height(1.dp)
@@ -332,27 +448,8 @@ fun NavigationItemSeparator(
         Modifier
             .then(modifier)
             .then(sizeModifier)
-            .background(FluentTheme.colors.stroke.surface.default.copy(0.2f))
+            .background(color)
     )
-}
-
-@Composable
-private fun Indicator(modifier: Modifier, display: Boolean) {
-    val selectionState = LocalSelectedItemPosition.current
-    val indicatorState = remember {
-        MutableTransitionState(display)
-    }
-    indicatorState.targetState = display
-    val animationModifier = if (selectionState != null) {
-        Modifier.indicatorOffsetAnimation(16.dp, indicatorState, selectionState)
-    } else {
-        val height by updateTransition(display).animateDp(transitionSpec = {
-            if (targetState) tween(FluentDuration.ShortDuration, easing = FluentEasing.FastInvokeEasing)
-            else tween(FluentDuration.QuickDuration, easing = FluentEasing.SoftDismissEasing)
-        }, targetValueByState = { if (it) 16.dp else 0.dp })
-        Modifier.height(height)
-    }
-    Box(modifier.width(3.dp).then(animationModifier).background(FluentTheme.colors.fillAccent.default, CircleShape))
 }
 
 @Composable
@@ -416,9 +513,9 @@ private fun Modifier.indicatorOffsetAnimation(
             }
         }
         val placeable = if (isVertical) {
-            measurable.measure(Constraints.fixed(constraints.maxWidth, currentSize.roundToInt().coerceAtLeast(0)))
+            measurable.measure(Constraints.fixedHeight(currentSize.roundToInt().coerceAtLeast(0)))
         } else {
-            measurable.measure(Constraints.fixed(currentSize.roundToInt().coerceAtLeast(0), constraints.maxHeight))
+            measurable.measure(Constraints.fixedWidth(currentSize.roundToInt().coerceAtLeast(0)))
         }
 
         layout(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Switcher.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Switcher.kt
@@ -9,7 +9,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -32,7 +38,7 @@ import com.konyaco.fluent.FluentTheme
 import com.konyaco.fluent.animation.FluentDuration
 import com.konyaco.fluent.animation.FluentEasing
 import com.konyaco.fluent.scheme.ValueVisualStateScheme
-import com.konyaco.fluent.scheme.collectCurrentScheme
+import com.konyaco.fluent.scheme.collectVisualState
 
 @Composable
 fun Switcher(
@@ -51,7 +57,7 @@ fun Switcher(
     // TODO: Draggable
     // TODO: Extract same logic
     val transition = updateTransition(checked)
-    val style = styles.collectCurrentScheme(interactionSource, !enabled)
+    val style = styles.schemeFor(interactionSource.collectVisualState(!enabled))
     Row(
         modifier = Modifier.clickable(
             indication = null,

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Switcher.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Switcher.kt
@@ -9,11 +9,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -22,14 +21,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.konyaco.fluent.FluentTheme
 import com.konyaco.fluent.animation.FluentDuration
 import com.konyaco.fluent.animation.FluentEasing
+import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.collectCurrentScheme
 
 @Composable
 fun Switcher(
@@ -38,15 +41,24 @@ fun Switcher(
     text: String? = null,
     textBefore: Boolean = false,
     enabled: Boolean = true,
+    styles: SwitcherStyleScheme = if (checked) {
+        SwitcherDefaults.selectedSwitcherStyle()
+    } else {
+        SwitcherDefaults.defaultSwitcherStyle()
+    },
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
     // TODO: Draggable
     // TODO: Extract same logic
-    val hovered by interactionSource.collectIsHoveredAsState()
-    val pressed by interactionSource.collectIsPressedAsState()
     val transition = updateTransition(checked)
+    val style = styles.collectCurrentScheme(interactionSource, !enabled)
     Row(
-        modifier = Modifier.clickable(indication = null, interactionSource = interactionSource, role = Role.Button) {
+        modifier = Modifier.clickable(
+            indication = null,
+            interactionSource = interactionSource,
+            role = Role.Button,
+            enabled = enabled
+        ) {
             onCheckStateChange(!checked)
         },
         verticalAlignment = Alignment.CenterVertically
@@ -56,59 +68,32 @@ fun Switcher(
                 Text(
                     modifier = Modifier.offset(y = (-1).dp),
                     text = it,
-                    color = if (enabled) FluentTheme.colors.text.text.primary
-                    else FluentTheme.colors.text.text.disabled
+                    color = style.labelColor
                 )
                 Spacer(Modifier.width(12.dp))
             }
         }
 
-        val colors = FluentTheme.colors
         val fillColor by animateColorAsState(
-            if (checked) when {
-                !enabled -> colors.fillAccent.disabled
-                pressed -> colors.fillAccent.tertiary
-                hovered -> colors.fillAccent.secondary
-                else -> colors.fillAccent.default
-            } else when {
-                !enabled -> colors.controlAlt.disabled
-                pressed -> colors.controlAlt.quaternary
-                hovered -> colors.controlAlt.tertiary
-                else -> colors.controlAlt.secondary
-            },
+            style.fillColor,
             tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
         )
 
         Box(
             modifier = Modifier.size(40.dp, 20.dp)
-                .border(
-                    1.dp, if (checked) when {
-                        !enabled -> FluentTheme.colors.fillAccent.disabled
-                        else -> Color.Transparent
-                    } else when {
-                        !enabled -> FluentTheme.colors.controlStrong.disabled
-                        else -> FluentTheme.colors.controlStrong.default
-                    }, CircleShape
-                )
+                .border(1.dp, style.borderBrush, CircleShape)
                 .clip(CircleShape)
                 .background(fillColor)
                 .padding(horizontal = 4.dp),
             contentAlignment = Alignment.CenterStart
         ) {
             val height by animateDpAsState(
-                when {
-                    pressed || hovered -> 14.dp
-                    else -> 12.dp
-                },
+                style.controlSize.height,
                 tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
             )
 
             val width by animateDpAsState(
-                when {
-                    pressed -> 17.dp
-                    hovered -> 14.dp
-                    else -> 12.dp
-                },
+                style.controlSize.width,
                 tween(FluentDuration.QuickDuration, easing = FluentEasing.FastInvokeEasing)
             )
 
@@ -154,23 +139,84 @@ fun Switcher(
                     modifier = Modifier.offset(y = (-1).dp),
                     text = it,
                     style = FluentTheme.typography.body,
-                    color = if (enabled) FluentTheme.colors.text.text.primary
-                    else FluentTheme.colors.text.text.disabled
+                    color = style.labelColor
                 )
             }
         }
     }
 }
 
-data class SwitcherColors(
-    val default: SwitcherColor,
-    val hovered: SwitcherColor,
-    val pressed: SwitcherColor,
-    val disabled: SwitcherColor
-)
+object SwitcherDefaults {
 
-data class SwitcherColor(
+    @Stable
+    @Composable
+    fun defaultSwitcherStyle(
+        default: SwitcherStyle = SwitcherStyle(
+            fillColor = FluentTheme.colors.controlAlt.secondary,
+            labelColor = FluentTheme.colors.text.text.primary,
+            controlColor = FluentTheme.colors.text.text.secondary,
+            controlSize = DpSize(width = 12.dp, height = 12.dp),
+            borderBrush = SolidColor(FluentTheme.colors.controlStrong.default)
+        ),
+        hovered: SwitcherStyle = default.copy(
+            fillColor = FluentTheme.colors.controlAlt.tertiary,
+            controlSize = DpSize(width = 14.dp, height = 14.dp)
+        ),
+        pressed: SwitcherStyle = default.copy(
+            fillColor = FluentTheme.colors.controlAlt.quaternary,
+            controlSize = DpSize(width = 17.dp, height = 14.dp)
+        ),
+        disabled: SwitcherStyle = default.copy(
+            fillColor = FluentTheme.colors.controlAlt.disabled,
+            borderBrush = SolidColor(FluentTheme.colors.controlStrong.disabled),
+            controlColor = FluentTheme.colors.text.text.disabled,
+            labelColor = FluentTheme.colors.text.text.disabled
+        )
+    ) = SwitcherStyleScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+
+    @Stable
+    @Composable
+    fun selectedSwitcherStyle(
+        default: SwitcherStyle = SwitcherStyle(
+            fillColor = FluentTheme.colors.fillAccent.default,
+            labelColor = FluentTheme.colors.text.text.primary,
+            controlColor = FluentTheme.colors.text.onAccent.primary,
+            controlSize = DpSize(width = 12.dp, height = 12.dp),
+            borderBrush = SolidColor(Color.Transparent)
+        ),
+        hovered: SwitcherStyle = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.secondary,
+            controlSize = DpSize(width = 14.dp, height = 14.dp)
+        ),
+        pressed: SwitcherStyle = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.tertiary,
+            controlSize = DpSize(width = 17.dp, height = 14.dp)
+        ),
+        disabled: SwitcherStyle = default.copy(
+            fillColor = FluentTheme.colors.fillAccent.disabled,
+            borderBrush = SolidColor(FluentTheme.colors.fillAccent.disabled),
+            controlColor = FluentTheme.colors.text.onAccent.disabled,
+            labelColor = FluentTheme.colors.text.text.disabled
+        )
+    ) = SwitcherStyleScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+}
+
+typealias SwitcherStyleScheme = ValueVisualStateScheme<SwitcherStyle>
+
+data class SwitcherStyle(
     val fillColor: Color,
-    val textColor: Color,
+    val labelColor: Color,
+    val controlColor: Color,
+    val controlSize: DpSize,
     val borderBrush: Brush
 )

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Switcher.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Switcher.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.unit.dp
 import com.konyaco.fluent.FluentTheme
 import com.konyaco.fluent.animation.FluentDuration
 import com.konyaco.fluent.animation.FluentEasing
-import com.konyaco.fluent.scheme.ValueVisualStateScheme
+import com.konyaco.fluent.scheme.PentaVisualScheme
 import com.konyaco.fluent.scheme.collectVisualState
 
 @Composable
@@ -217,7 +217,7 @@ object SwitcherDefaults {
     )
 }
 
-typealias SwitcherStyleScheme = ValueVisualStateScheme<SwitcherStyle>
+typealias SwitcherStyleScheme = PentaVisualScheme<SwitcherStyle>
 
 data class SwitcherStyle(
     val fillColor: Color,

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TextField.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TextField.kt
@@ -4,7 +4,13 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -35,7 +41,7 @@ import com.konyaco.fluent.LocalTextStyle
 import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
 import com.konyaco.fluent.scheme.FocusableValueVisualStateScheme
-import com.konyaco.fluent.scheme.collectCurrentScheme
+import com.konyaco.fluent.scheme.collectVisualState
 
 @Composable
 fun TextField(
@@ -54,7 +60,7 @@ fun TextField(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     colors: TextFieldColorScheme = TextFieldDefaults.defaultTextFieldColors()
 ) {
-    val color = colors.collectCurrentScheme(interactionSource, !enabled)
+    val color = colors.schemeFor(interactionSource.collectVisualState(!enabled, true))
     Column(modifier) {
         if (header != null) {
             header()

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TextField.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TextField.kt
@@ -60,7 +60,7 @@ fun TextField(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     colors: TextFieldColorScheme = TextFieldDefaults.defaultTextFieldColors()
 ) {
-    val color = colors.schemeFor(interactionSource.collectVisualState(!enabled, true))
+    val color = colors.schemeFor(interactionSource.collectVisualState(!enabled, focusFirst = true))
     Column(modifier) {
         if (header != null) {
             header()

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TextField.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TextField.kt
@@ -4,14 +4,15 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -21,15 +22,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.konyaco.fluent.FluentTheme
+import com.konyaco.fluent.LocalContentColor
 import com.konyaco.fluent.LocalTextStyle
 import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
+import com.konyaco.fluent.scheme.FocusableValueVisualStateScheme
+import com.konyaco.fluent.scheme.collectCurrentScheme
 
 @Composable
 fun TextField(
@@ -44,12 +50,11 @@ fun TextField(
     keyboardActions: KeyboardActions = KeyboardActions(),
     maxLines: Int = Int.MAX_VALUE,
     header: (@Composable () -> Unit)? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+    placeholder: (@Composable () -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: TextFieldColorScheme = TextFieldDefaults.defaultTextFieldColors()
 ) {
-    val hovered by interactionSource.collectIsHoveredAsState()
-    val pressed by interactionSource.collectIsPressedAsState()
-    val focused by interactionSource.collectIsFocusedAsState()
-
+    val color = colors.collectCurrentScheme(interactionSource, !enabled)
     Column(modifier) {
         if (header != null) {
             header()
@@ -60,59 +65,123 @@ fun TextField(
                 .clip(RoundedCornerShape(4.dp)),
             value = value,
             onValueChange = onValueChange,
-            textStyle = LocalTextStyle.current.copy(
-                color = if (enabled) FluentTheme.colors.text.text.primary
-                else FluentTheme.colors.text.text.disabled
-            ),
+            textStyle = LocalTextStyle.current.copy(color = color.contentColor),
             enabled = enabled,
             readOnly = readOnly,
             singleLine = singleLine,
             visualTransformation = visualTransformation,
             maxLines = maxLines,
             keyboardActions = keyboardActions,
-            cursorBrush = SolidColor(FluentTheme.colors.text.text.primary),
+            cursorBrush = color.cursorBrush,
             keyboardOptions = keyboardOptions,
             interactionSource = interactionSource,
             decorationBox = { innerTextField ->
-                Layer(
-                    modifier = Modifier.hoverable(interactionSource)
-                        .drawBottomLine(enabled) { focused },
-                    shape = RoundedCornerShape(4.dp),
-                    color = when {
-                        !enabled -> FluentTheme.colors.control.disabled
-                        pressed || focused -> FluentTheme.colors.control.inputActive
-                        hovered -> FluentTheme.colors.control.secondary
-                        else -> FluentTheme.colors.control.default
-                    },
-                    border = BorderStroke(
-                        1.dp,
-                        if (focused || pressed) SolidColor(FluentTheme.colors.stroke.control.default)
-                        else FluentTheme.colors.borders.textControl
-                    ),
-                    backgroundSizing = BackgroundSizing.OuterBorderEdge
-                ) {
-                    Box(
-                        Modifier.offset(y = (-1).dp).padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 3.dp),
-                        Alignment.CenterStart
-                    ) {
-                        innerTextField()
-                    }
-                }
+                TextFieldDefaults.DecorationBox(
+                    color = color,
+                    interactionSource = interactionSource,
+                    innerTextField = innerTextField,
+                    value = value.text,
+                    enabled = enabled,
+                    placeholder = placeholder
+                )
             }
         )
     }
 }
 
+object TextFieldDefaults {
+
+    @Stable
+    @Composable
+    fun defaultTextFieldColors(
+        default: TextFieldColor = TextFieldColor(
+            fillColor = FluentTheme.colors.control.default,
+            contentColor = FluentTheme.colors.text.text.primary,
+            placeholderColor = FluentTheme.colors.text.text.secondary,
+            bottomLineFillColor = FluentTheme.colors.stroke.controlStrong.default,
+            borderBrush = FluentTheme.colors.borders.textControl,
+            cursorBrush = SolidColor(FluentTheme.colors.text.text.primary)
+        ),
+        focused: TextFieldColor = default.copy(
+            fillColor = FluentTheme.colors.control.inputActive,
+            bottomLineFillColor = FluentTheme.colors.fillAccent.default,
+            borderBrush = SolidColor(FluentTheme.colors.stroke.control.default)
+        ),
+        hovered: TextFieldColor = default.copy(
+            fillColor = FluentTheme.colors.control.secondary
+        ),
+        pressed: TextFieldColor = default.copy(
+            fillColor = FluentTheme.colors.control.inputActive,
+            borderBrush = SolidColor(FluentTheme.colors.stroke.control.default)
+        ),
+        disabled: TextFieldColor = default.copy(
+            contentColor = FluentTheme.colors.text.text.disabled,
+            placeholderColor = FluentTheme.colors.text.text.disabled,
+            bottomLineFillColor = Color.Transparent,
+        )
+    ) = TextFieldColorScheme(
+        default = default,
+        focused = focused,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+
+    @Composable
+    fun DecorationBox(
+        value: String,
+        interactionSource: MutableInteractionSource,
+        enabled: Boolean,
+        color: TextFieldColor,
+        modifier: Modifier = Modifier.drawBottomLine(enabled, color, interactionSource),
+        placeholder: (@Composable () -> Unit)?,
+        innerTextField: @Composable () -> Unit,
+    ) {
+        Layer(
+            modifier = modifier.hoverable(interactionSource),
+            shape = RoundedCornerShape(4.dp),
+            color = color.fillColor,
+            border = BorderStroke(1.dp, color.borderBrush),
+            backgroundSizing = BackgroundSizing.OuterBorderEdge
+        ) {
+            Box(
+                Modifier.offset(y = (-1).dp).padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 3.dp),
+                Alignment.CenterStart
+            ) {
+                innerTextField()
+                if (value.isEmpty() && placeholder != null) {
+                    CompositionLocalProvider(
+                        LocalContentColor provides color.placeholderColor,
+                        LocalTextStyle provides LocalTextStyle.current.copy(color = color.placeholderColor)
+                    ) {
+                        placeholder()
+                    }
+                }
+            }
+        }
+    }
+}
+
+typealias TextFieldColorScheme = FocusableValueVisualStateScheme<TextFieldColor>
+
+@Immutable
+data class TextFieldColor(
+    val fillColor: Color,
+    val contentColor: Color,
+    val placeholderColor: Color,
+    val bottomLineFillColor: Color,
+    val borderBrush: Brush,
+    val cursorBrush: Brush
+)
+
 @Composable
-private fun Modifier.drawBottomLine(enabled: Boolean, focused: () -> Boolean): Modifier {
+private fun Modifier.drawBottomLine(enabled: Boolean, color: TextFieldColor, interactionSource: MutableInteractionSource): Modifier {
+    val isFocused by interactionSource.collectIsFocusedAsState()
     return if (enabled) {
         val height by rememberUpdatedState(with(LocalDensity.current) {
-            (if (focused()) 2.dp else 1.dp).toPx()
+            (if (isFocused) 2.dp else 1.dp).toPx()
         })
-        val fillColor by rememberUpdatedState(
-            if (focused()) FluentTheme.colors.fillAccent.default
-            else FluentTheme.colors.stroke.controlStrong.default
-        )
+        val fillColor by rememberUpdatedState(color.bottomLineFillColor)
         drawWithContent {
             drawContent()
             drawRect(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TextField.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TextField.kt
@@ -40,7 +40,7 @@ import com.konyaco.fluent.LocalContentColor
 import com.konyaco.fluent.LocalTextStyle
 import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
-import com.konyaco.fluent.scheme.FocusableValueVisualStateScheme
+import com.konyaco.fluent.scheme.PentaVisualScheme
 import com.konyaco.fluent.scheme.collectVisualState
 
 @Composable
@@ -168,7 +168,7 @@ object TextFieldDefaults {
     }
 }
 
-typealias TextFieldColorScheme = FocusableValueVisualStateScheme<TextFieldColor>
+typealias TextFieldColorScheme = PentaVisualScheme<TextFieldColor>
 
 @Immutable
 data class TextFieldColor(

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/scheme/VisualStateScheme.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/scheme/VisualStateScheme.kt
@@ -9,11 +9,13 @@ fun interface VisualStateScheme<Scheme: Any> {
     fun schemeFor(state: VisualState): Scheme
 }
 
-interface ValueVisualStateScheme<Scheme: Any>: VisualStateScheme<Scheme> {
-    val default: Scheme
-    val hovered: Scheme
-    val pressed: Scheme
+@Immutable
+data class ValueVisualStateScheme<Scheme: Any>(
+    val default: Scheme,
+    val hovered: Scheme,
+    val pressed: Scheme,
     val disabled: Scheme
+): VisualStateScheme<Scheme> {
 
     override fun schemeFor(state: VisualState): Scheme = when(state) {
         VisualState.Default -> default
@@ -22,21 +24,6 @@ interface ValueVisualStateScheme<Scheme: Any>: VisualStateScheme<Scheme> {
         VisualState.Disabled -> disabled
     }
 
-}
-
-@Immutable
-class SelectableVisualStateScheme<Scheme: Any>(
-    private val default: VisualStateScheme<Scheme>,
-    private val selected: VisualStateScheme<Scheme>,
-    private val selectedState: () -> Boolean = { false },
-): VisualStateScheme<Scheme> {
-    override fun schemeFor(state: VisualState): Scheme {
-        return if (selectedState()) {
-            selected.schemeFor(state)
-        } else {
-            default.schemeFor(state)
-        }
-    }
 }
 
 fun <T: Any> VisualStateScheme<T>.collectCurrentScheme(isHovered: Boolean = false, isPressed: Boolean = false, disabled: Boolean = false): T {

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/scheme/VisualStateScheme.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/scheme/VisualStateScheme.kt
@@ -58,30 +58,13 @@ fun interface VisualStateScheme<T> {
 }
 
 @Immutable
-data class ValueVisualStateScheme<T>(
-    val default: T,
-    val hovered: T,
-    val pressed: T,
-    val disabled: T
-) : VisualStateScheme<T> {
-    override fun schemeFor(state: VisualState): T = when (state) {
-        VisualState.Hovered -> hovered
-        VisualState.Pressed -> pressed
-        VisualState.Disabled -> disabled
-        else -> default
-    }
-}
-
-interface FocusableVisualStateScheme<T> : VisualStateScheme<T>
-
-@Immutable
-data class FocusableValueVisualStateScheme<T>(
+data class PentaVisualScheme<T>(
     val default: T,
     val hovered: T,
     val pressed: T,
     val disabled: T,
-    val focused: T
-) : FocusableVisualStateScheme<T> {
+    val focused: T = default
+) : VisualStateScheme<T> {
     override fun schemeFor(state: VisualState): T = when (state) {
         VisualState.Default -> default
         VisualState.Hovered -> hovered

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/scheme/VisualStateScheme.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/scheme/VisualStateScheme.kt
@@ -9,11 +9,12 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 
 @Composable
-fun InteractionSource.collectVisualState(disabled: Boolean, focusable: Boolean = false): VisualState {
+fun InteractionSource.collectVisualState(disabled: Boolean, focusFirst: Boolean = false): VisualState {
     val pressed by collectIsPressedAsState()
     val hovered by collectIsHoveredAsState()
     val focused by collectIsFocusedAsState()
-    return VisualState.fromInteraction(pressed, hovered, disabled, if (focusable) focused else false)
+    return if (focusFirst) VisualState.fromInteractionFocusFirst(pressed, hovered, disabled, focused)
+    else VisualState.fromInteraction(pressed, hovered, disabled, focused)
 }
 
 enum class VisualState {
@@ -21,6 +22,21 @@ enum class VisualState {
 
     companion object {
         fun fromInteraction(
+            pressed: Boolean,
+            hovered: Boolean,
+            disabled: Boolean,
+            focused: Boolean
+        ): VisualState {
+            return when {
+                disabled -> Disabled
+                pressed -> Pressed
+                hovered -> Hovered
+                focused -> Focused
+                else -> Default
+            }
+        }
+
+        fun fromInteractionFocusFirst(
             pressed: Boolean,
             hovered: Boolean,
             disabled: Boolean,

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/scheme/VisualStateScheme.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/scheme/VisualStateScheme.kt
@@ -1,6 +1,7 @@
 package com.konyaco.fluent.scheme
 
 import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.runtime.*
@@ -18,10 +19,31 @@ data class ValueVisualStateScheme<Scheme: Any>(
 ): VisualStateScheme<Scheme> {
 
     override fun schemeFor(state: VisualState): Scheme = when(state) {
+        VisualState.Hovered -> hovered
+        VisualState.Pressed -> pressed
+        VisualState.Disabled -> disabled
+        else -> default
+    }
+
+}
+
+interface FocusableVisualStateScheme<Scheme: Any>: VisualStateScheme<Scheme>
+
+@Immutable
+data class FocusableValueVisualStateScheme<Scheme: Any>(
+    val default: Scheme,
+    val hovered: Scheme,
+    val pressed: Scheme,
+    val disabled: Scheme,
+    val focused: Scheme
+): FocusableVisualStateScheme<Scheme> {
+
+    override fun schemeFor(state: VisualState): Scheme = when(state) {
         VisualState.Default -> default
         VisualState.Hovered -> hovered
         VisualState.Pressed -> pressed
         VisualState.Disabled -> disabled
+        VisualState.Focused -> focused
     }
 
 }
@@ -42,6 +64,29 @@ fun <T: Any> VisualStateScheme<T>.collectCurrentScheme(interactionSource: Intera
     return collectCurrentScheme(isHovered, isPressed, disabled)
 }
 
+fun <T: Any> FocusableVisualStateScheme<T>.collectCurrentScheme(
+    isHovered: Boolean = false,
+    isPressed: Boolean = false,
+    disabled: Boolean = false,
+    focused: Boolean = false
+): T {
+    return when {
+        disabled -> schemeFor(VisualState.Disabled)
+        focused -> schemeFor(VisualState.Focused)
+        isPressed -> schemeFor(VisualState.Pressed)
+        isHovered -> schemeFor(VisualState.Hovered)
+        else -> schemeFor(VisualState.Default)
+    }
+}
+
+@Composable
+fun <T: Any> FocusableVisualStateScheme<T>.collectCurrentScheme(interactionSource: InteractionSource, disabled: Boolean = false): T {
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    return collectCurrentScheme(isHovered, isPressed, disabled, isFocused)
+}
+
 sealed interface VisualState {
     data object Default: VisualState
 
@@ -50,4 +95,6 @@ sealed interface VisualState {
     data object Pressed: VisualState
 
     data object Disabled: VisualState
+
+    data object Focused: VisualState
 }

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/App.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/App.kt
@@ -67,6 +67,7 @@ fun App() {
                 TextField(
                     value = textFieldValue,
                     onValueChange = { textFieldValue = it },
+                    placeholder = { Text("Search") },
                     modifier = Modifier.fillMaxWidth().focusHandle()
                 )
             },


### PR DESCRIPTION
1. ButtonColorScheme
2. CheckBoxColorScheme
3. MenuItemColorScheme
4. RadioButtonStyleScheme
5. NavigationItemColorScheme, `NavigationItem.Indicator` and `NavigationDefaults.VerticalIndicator`
6. SwitcherStyleScheme
7. TextFieldColorScheme, `TextField.placeholder`, `TextFieldDefaults.DecorationBox`