### PR TITLE
Bump to compose 1.6.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Thank you for using our library. We look forward to receiving your feedback and 
 ### Add Dependency
 
 ```kts
-implementation("com.konyaco:fluent:0.0.1-dev.7")
-implementation("com.konyaco:fluent-icons-extended:0.0.1-dev.7") // If you want to use full fluent icons.
+implementation("com.konyaco:fluent:0.0.1-dev.8")
+implementation("com.konyaco:fluent-icons-extended:0.0.1-dev.8") // If you want to use full fluent icons.
 ```
 
 ### Example

--- a/build-plugin/src/main/java/com/konyaco/fluent/plugin/build/BuildConfig.kt
+++ b/build-plugin/src/main/java/com/konyaco/fluent/plugin/build/BuildConfig.kt
@@ -8,7 +8,7 @@ object BuildConfig {
 
     const val packageName = "$group.fluent"
 
-    const val libraryVersion = "0.0.1-dev.7"
+    const val libraryVersion = "0.0.1-dev.8"
 
     object Android {
         const val compileSdkVersion = 34

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 activityCompose = "1.8.2"
 haze = "0.6.2"
-kotlin = "1.9.0"
-ksp = "1.9.0-1.0.13"
-compose = "1.6.1"
+kotlin = "1.9.23"
+ksp = "1.9.23-1.0.20"
+compose = "1.6.10"
 androidGradlePlugin = "8.3.2"
 androidBuildTools = "31.3.2"
 windowStyler = "0.3.3-SNAPSHOT"


### PR DESCRIPTION
I'm considering to release dev8, because the compose 1.6.10 is an important update. What do you think?