### PR TITLE
[gallery] UI Improve.

### DIFF
--- a/gallery/build.gradle.kts
+++ b/gallery/build.gradle.kts
@@ -44,6 +44,8 @@ kotlin {
             dependencies {
                 implementation(compose.preview)
                 implementation(libs.window.styler)
+                implementation(libs.jna.platform)
+                implementation(libs.jna)
             }
         }
         val desktopTest by getting

--- a/gallery/src/androidMain/kotlin/com/konyaco/fluent/gallery/MainActivity.kt
+++ b/gallery/src/androidMain/kotlin/com/konyaco/fluent/gallery/MainActivity.kt
@@ -2,14 +2,20 @@ package com.konyaco.fluent.gallery
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import com.konyaco.fluent.gallery.component.rememberComponentNavigator
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
+            val componentNavigator = rememberComponentNavigator()
+            BackHandler(componentNavigator.latestBackEntry != null) {
+                componentNavigator.navigateUp()
+            }
             GalleryTheme {
-                App()
+                App(componentNavigator)
             }
         }
     }

--- a/gallery/src/androidMain/kotlin/com/konyaco/fluent/gallery/MainActivity.kt
+++ b/gallery/src/androidMain/kotlin/com/konyaco/fluent/gallery/MainActivity.kt
@@ -11,7 +11,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val componentNavigator = rememberComponentNavigator()
-            BackHandler(componentNavigator.latestBackEntry != null) {
+            BackHandler(componentNavigator.canNavigateUp) {
                 componentNavigator.navigateUp()
             }
             GalleryTheme {

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/ComponentGroupInfo.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/ComponentGroupInfo.kt
@@ -38,7 +38,7 @@ object ComponentGroupInfo {
     @ComponentGroup("Flash", index = 9)
     const val Motion = "Motion"
 
-    @ComponentGroup("Navigation", index = 10)
+    @ComponentGroup("Navigation", index = 10, packageMap = "$screenPackage.navigation")
     const val Navigation = "Navigation"
 
     @ComponentGroup("ArrowSort", index = 11)

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/ComponentNavigator.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/ComponentNavigator.kt
@@ -1,6 +1,8 @@
 package com.konyaco.fluent.gallery.component
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 
@@ -13,6 +15,8 @@ interface ComponentNavigator {
     val currentBackstack: List<ComponentItem>
 
     val latestBackEntry: ComponentItem?
+
+    val canNavigateUp: Boolean
 
 }
 
@@ -35,6 +39,10 @@ private class ComponentNavigatorImpl(startItem: ComponentItem) : ComponentNaviga
                 backstack.removeLast()
             } while (backstack.lastOrNull().let { it != null && it.content == null })
         }
+    }
+
+    override val canNavigateUp: Boolean by derivedStateOf {
+        backstack.count { it.content != null } > 1
     }
 
     override val currentBackstack: List<ComponentItem>

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/ComponentNavigator.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/ComponentNavigator.kt
@@ -1,6 +1,45 @@
 package com.konyaco.fluent.gallery.component
 
-fun interface ComponentNavigator {
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+
+interface ComponentNavigator {
+
     fun navigate(componentItem: ComponentItem)
 
+    fun navigateUp()
+
+    val currentBackstack: List<ComponentItem>
+
+    val latestBackEntry: ComponentItem?
+
+}
+
+@Composable
+fun rememberComponentNavigator(startItem: ComponentItem = components.first()): ComponentNavigator {
+    return remember { ComponentNavigatorImpl(startItem) }
+}
+
+private class ComponentNavigatorImpl(startItem: ComponentItem) : ComponentNavigator {
+
+    private val backstack = mutableStateListOf<ComponentItem>().apply { add(startItem) }
+
+    override fun navigate(componentItem: ComponentItem) {
+        backstack.add(componentItem)
+    }
+
+    override fun navigateUp() {
+        if (backstack.isNotEmpty()) {
+            do {
+                backstack.removeLast()
+            } while (backstack.lastOrNull().let { it != null && it.content == null })
+        }
+    }
+
+    override val currentBackstack: List<ComponentItem>
+        get() = backstack
+
+    override val latestBackEntry: ComponentItem?
+        get() = backstack.lastOrNull()
 }

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/Main.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/Main.kt
@@ -7,28 +7,45 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
-import com.mayakapps.compose.windowstyler.WindowBackdrop
-import com.mayakapps.compose.windowstyler.WindowStyle
+import com.konyaco.fluent.gallery.component.rememberComponentNavigator
+import com.konyaco.fluent.gallery.jna.windows.structure.isWindows10OrLater
+import com.konyaco.fluent.gallery.window.WindowsWindowFrame
 import fluentdesign.gallery.generated.resources.Res
 import fluentdesign.gallery.generated.resources.icon
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.skiko.hostOs
 
-@OptIn(ExperimentalResourceApi::class)
 fun main() = application {
+    val state = rememberWindowState(
+        position = WindowPosition(Alignment.Center),
+        size = DpSize(1280.dp, 720.dp)
+    )
     Window(
         onCloseRequest = ::exitApplication,
-        state = rememberWindowState(position = WindowPosition(Alignment.Center), size = DpSize(1280.dp, 720.dp)),
+        state = state,
         title = "Compose Fluent Design Gallery",
         icon = painterResource(Res.drawable.icon)
     ) {
-        GalleryTheme {
-            //TODO Make Window transparent.
-            WindowStyle(
-                isDarkTheme = LocalStore.current.darkMode,
-                backdropType = WindowBackdrop.Mica
-            )
-            App()
+        val supportBackdrop = hostOs.isWindows && isWindows10OrLater()
+        GalleryTheme(!supportBackdrop) {
+            if (supportBackdrop) {
+                val navigator = rememberComponentNavigator()
+                WindowsWindowFrame(
+                    onCloseRequest = { exitApplication() },
+                    icon = painterResource(Res.drawable.icon),
+                    title = "Compose Fluent Design Gallery",
+                    backButtonEnabled = navigator.canNavigateUp,
+                    backButtonClick = { navigator.navigateUp() },
+                    state = state
+                ) {
+                    App(navigator)
+                }
+            } else {
+                App()
+            }
+
         }
+
     }
 }
+

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/ComposeWindowProcedure.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/ComposeWindowProcedure.kt
@@ -1,0 +1,198 @@
+package com.konyaco.fluent.gallery.jna.windows
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.ui.awt.ComposeWindow
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTBOTTOM
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTBOTTOMLEFT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTBOTTOMRIGHT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTLEFT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTRIGHT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTTOP
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTTOPLEFT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTTOPRIGHT
+import com.konyaco.fluent.gallery.jna.windows.structure.WindowMargins
+import com.mayakapps.compose.windowstyler.findSkiaLayer
+import com.sun.jna.Native
+import com.sun.jna.NativeLibrary
+import com.sun.jna.Pointer
+import com.sun.jna.platform.win32.WinDef.HWND
+import com.sun.jna.platform.win32.WinDef.UINT
+import com.sun.jna.platform.win32.WinDef.LPARAM
+import com.sun.jna.platform.win32.WinDef.WPARAM
+import com.sun.jna.platform.win32.WinDef.LRESULT
+import com.sun.jna.platform.win32.BaseTSD.LONG_PTR
+import com.sun.jna.platform.win32.WinUser
+import com.sun.jna.platform.win32.WinUser.WM_DESTROY
+import com.sun.jna.platform.win32.WinUser.WM_SIZE
+import com.sun.jna.platform.win32.WinUser.WS_CAPTION
+import com.sun.jna.platform.win32.WinUser.WS_SYSMENU
+import java.awt.Window
+
+internal class ComposeWindowProcedure(
+    private val window: Window,
+    private val hitTest: (x: Float, y: Float) -> Int,
+    private val onWindowInsetUpdate: (WindowInsets) -> Unit
+) : WindowProcedure {
+    private val windowPointer = (this.window as? ComposeWindow)
+        ?.windowHandle
+        ?.let(::Pointer)
+        ?: Native.getWindowPointer(this.window)
+
+    val windowHandle = HWND(windowPointer)
+
+    private var hitResult = 1
+
+    // See https://learn.microsoft.com/en-us/windows/win32/winmsg/about-messages-and-message-queues#system-defined-messages
+    private val WM_NCCALCSIZE = 0x0083
+    private val WM_NCHITTEST = 0x0084
+    private val margins = WindowMargins(
+        leftBorderWidth = 0,
+        topBorderHeight = 0,
+        rightBorderWidth = -1,
+        bottomBorderHeight = -1
+    )
+
+    //     The default window procedure to call its methods when the default method behaviour is desired/sufficient
+    private var defaultWindowProcedure = User32Extend.instance?.setWindowLong(windowHandle, WinUser.GWL_WNDPROC, this) ?: LONG_PTR(-1)
+
+    private var dpi = UINT(0)
+    private var width = 0
+    private var height = 0
+    private var frameX = 0
+    private var frameY = 0
+    private var edgeX = 0
+    private var edgeY = 0
+    private var padding = 0
+    private var isMaximized = User32Extend.instance?.isWindowInMaximized(windowHandle) ?: false
+
+    val skiaLayerProcedure = (window as? ComposeWindow)?.findSkiaLayer()?.let {
+        SkiaLayerWindowProcedure(
+            skiaLayer = it,
+            hitTest = { x, y ->
+                val horizontalPadding = frameX
+                val verticalPadding = frameY
+                // Hit test for resizer border
+                hitResult = when {
+                    // skip resizer border hit test if window is maximized
+                    isMaximized -> hitTest(x, y)
+                    x <= horizontalPadding && y > verticalPadding && y < height - verticalPadding -> HTLEFT
+                    x <= horizontalPadding && y <= verticalPadding -> HTTOPLEFT
+                    x <= horizontalPadding -> HTBOTTOMLEFT
+                    y <= verticalPadding && x > horizontalPadding && x < width - horizontalPadding -> HTTOP
+                    y <= verticalPadding && x <= horizontalPadding -> HTTOPLEFT
+                    y <= verticalPadding -> HTTOPRIGHT
+                    x >= width - horizontalPadding && y > verticalPadding && y < height - verticalPadding -> HTRIGHT
+                    x >= width - horizontalPadding && y <= verticalPadding -> HTTOPRIGHT
+                    x >= width - horizontalPadding -> HTBOTTOMRIGHT
+                    y >= height - verticalPadding && x > horizontalPadding && x < width - horizontalPadding -> HTBOTTOM
+                    y >= height - verticalPadding && x <= horizontalPadding -> HTBOTTOMLEFT
+                    y >= height - verticalPadding -> HTBOTTOMRIGHT
+                    // else hit test by user
+                    else -> hitTest(x, y)
+                }
+                hitResult
+            }
+        )
+    }
+
+    init {
+        enableResizability()
+        enableBorderAndShadow()
+    }
+
+    override fun callback(hWnd: HWND, uMsg: Int, wParam: WPARAM, lParam: LPARAM): LRESULT {
+        return when (uMsg) {
+            // Returns 0 to make the window not draw the non-client area (title bar and border)
+            // thus effectively making all the window our client area
+            WM_NCCALCSIZE -> {
+                if (wParam.toInt() == 0) {
+                    User32Extend.instance?.CallWindowProc(defaultWindowProcedure, hWnd, uMsg, wParam, lParam) ?: LRESULT(0)
+                } else {
+                    val user32 = User32Extend.instance ?: return LRESULT(0)
+                    dpi = user32.GetDpiForWindow(hWnd)
+                    frameX = user32.GetSystemMetricsForDpi(WinUser.SM_CXFRAME, dpi)
+                    frameY = user32.GetSystemMetricsForDpi(WinUser.SM_CYFRAME, dpi)
+                    edgeX = user32.GetSystemMetricsForDpi(WinUser.SM_CXEDGE, dpi)
+                    edgeY = user32.GetSystemMetricsForDpi(WinUser.SM_CYEDGE, dpi)
+                    padding = user32.GetSystemMetricsForDpi(WinUser.SM_CXPADDEDBORDER, dpi)
+                    isMaximized = user32.isWindowInMaximized(hWnd)
+                    // Edge inset padding for non-client area
+                    onWindowInsetUpdate(
+                        WindowInsets(
+                            left = if (isMaximized) {
+                                frameX + padding
+                            } else {
+                                edgeX
+                            },
+                            right = if (isMaximized) {
+                                frameX + padding
+                            } else {
+                                edgeX
+                            },
+                            top = if (isMaximized) {
+                                frameY + padding
+                            } else {
+                                edgeY
+                            },
+                            bottom = if (isMaximized) {
+                                frameY + padding
+                            } else {
+                                edgeY
+                            }
+                        )
+                    )
+                    LRESULT(0)
+                }
+
+            }
+
+            WM_NCHITTEST -> {
+                // Hit test result return
+                return LRESULT(hitResult.toLong())
+            }
+
+            WM_DESTROY -> {
+                User32Extend.instance?.CallWindowProc(defaultWindowProcedure, hWnd, uMsg, wParam, lParam) ?: LRESULT(0)
+            }
+
+            WM_SIZE -> {
+                width = lParam.toInt() and 0xFFFF
+                height = (lParam.toInt() shr 16) and 0xFFFF
+                User32Extend.instance?.CallWindowProc(defaultWindowProcedure, hWnd, uMsg, wParam, lParam) ?: LRESULT(0)
+            }
+
+            else -> {
+                User32Extend.instance?.CallWindowProc(defaultWindowProcedure, hWnd, uMsg, wParam, lParam) ?: LRESULT(0)
+            }
+        }
+    }
+
+    /**
+     * For this to take effect, also set `resizable` argument of Compose Window to `true`.
+     */
+    private fun enableResizability() {
+        // Enable window resizing and remove standard caption bar
+        User32Extend.instance?.updateWindowStyle(windowHandle) { oldStyle ->
+            (oldStyle or WS_CAPTION) and WS_SYSMENU.inv()
+        }
+    }
+
+    /**
+     * To disable window border and shadow, pass (0, 0, 0, 0) as window margins
+     * (or, simply, don't call this function).
+     */
+    private fun enableBorderAndShadow() {
+        val dwmApi = "dwmapi"
+            .runCatching(NativeLibrary::getInstance)
+            .onFailure { println("Could not load dwmapi library") }
+            .getOrNull()
+        dwmApi
+            ?.runCatching { getFunction("DwmExtendFrameIntoClientArea") }
+            ?.onFailure { println("Could not enable window native decorations (border/shadow/rounded corners)") }
+            ?.getOrNull()
+            ?.invoke(arrayOf(windowHandle, margins))
+    }
+
+
+
+}

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/ComposeWindowProcedure.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/ComposeWindowProcedure.kt
@@ -10,6 +10,8 @@ import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTRIGHT
 import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTTOP
 import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTTOPLEFT
 import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTTOPRIGHT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_NCCALCSIZE
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_NCHITTEST
 import com.konyaco.fluent.gallery.jna.windows.structure.WindowMargins
 import com.mayakapps.compose.windowstyler.findSkiaLayer
 import com.sun.jna.Native
@@ -42,9 +44,6 @@ internal class ComposeWindowProcedure(
 
     private var hitResult = 1
 
-    // See https://learn.microsoft.com/en-us/windows/win32/winmsg/about-messages-and-message-queues#system-defined-messages
-    private val WM_NCCALCSIZE = 0x0083
-    private val WM_NCHITTEST = 0x0084
     private val margins = WindowMargins(
         leftBorderWidth = 0,
         topBorderHeight = 0,

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/SkiaLayerWindowProcedure.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/SkiaLayerWindowProcedure.kt
@@ -1,0 +1,76 @@
+package com.konyaco.fluent.gallery.jna.windows
+
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTCLIENT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTMAXBUTTON
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTTRANSPANRENT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_LBUTTONDOWN
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_LBUTTONUP
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_MOUSEMOVE
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_NCHITTEST
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_NCLBUTTONDOWN
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_NCLBUTTONUP
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.WM_NCMOUSEMOVE
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.platform.win32.BaseTSD
+import com.sun.jna.platform.win32.WinDef
+import com.sun.jna.platform.win32.WinDef.HWND
+import com.sun.jna.platform.win32.WinDef.LRESULT
+import com.sun.jna.platform.win32.WinDef.POINT
+import com.sun.jna.platform.win32.WinUser
+import org.jetbrains.skiko.SkiaLayer
+
+class SkiaLayerWindowProcedure(
+    skiaLayer: SkiaLayer,
+    private val hitTest: (x: Float, y: Float) -> Int
+): WindowProcedure {
+
+    private val windowHandle = HWND(Pointer(skiaLayer.windowHandle))
+    private val contentHandle = HWND(skiaLayer.canvas.let(Native::getComponentPointer))
+    private val defaultWindowProcedure = User32Extend.instance?.setWindowLong(contentHandle, WinUser.GWL_WNDPROC, this) ?: BaseTSD.LONG_PTR(-1)
+
+    private var hitResult = 1
+
+     override fun callback(
+        hwnd: HWND,
+        uMsg: Int,
+        wParam: WinDef.WPARAM,
+        lParam: WinDef.LPARAM
+    ): LRESULT {
+
+        return when(uMsg) {
+
+            WM_NCHITTEST -> {
+                val x = lParam.toInt() and 0xFFFF
+                val y = (lParam.toInt() shr 16) and 0xFFFF
+                val point = POINT(x, y)
+                User32Extend.instance?.ScreenToClient(windowHandle, point)
+                hitResult = hitTest(point.x.toFloat(), point.y.toFloat())
+                point.clear()
+                when(hitResult) {
+                    HTCLIENT, HTMAXBUTTON -> LRESULT(hitResult.toLong())
+                    else -> LRESULT(HTTRANSPANRENT.toLong())
+                }
+            }
+
+            WM_NCMOUSEMOVE -> {
+                User32Extend.instance?.SendMessage(contentHandle, WM_MOUSEMOVE, wParam, lParam)
+                LRESULT(0)
+            }
+
+            WM_NCLBUTTONDOWN -> {
+                User32Extend.instance?.SendMessage(contentHandle, WM_LBUTTONDOWN, wParam, lParam)
+                LRESULT(0)
+            }
+
+            WM_NCLBUTTONUP -> {
+                User32Extend.instance?.SendMessage(contentHandle, WM_LBUTTONUP, wParam, lParam)
+                return LRESULT(0)
+            }
+
+            else -> {
+                User32Extend.instance?.CallWindowProc(defaultWindowProcedure, hwnd, uMsg, wParam, lParam) ?: LRESULT(0)
+            }
+        }
+    }
+}

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/User32Extend.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/User32Extend.kt
@@ -1,0 +1,74 @@
+package com.konyaco.fluent.gallery.jna.windows
+
+import com.sun.jna.Native
+import com.sun.jna.Platform
+import com.sun.jna.platform.win32.User32
+import com.sun.jna.platform.win32.WinDef.HWND
+import com.sun.jna.platform.win32.WinDef.WPARAM
+import com.sun.jna.platform.win32.WinDef.LPARAM
+import com.sun.jna.platform.win32.WinDef.LRESULT
+import com.sun.jna.platform.win32.WinUser.WindowProc
+import com.sun.jna.platform.win32.BaseTSD.LONG_PTR
+import com.sun.jna.platform.win32.WinDef.POINT
+import com.sun.jna.platform.win32.WinDef.UINT
+import com.sun.jna.platform.win32.WinUser
+import com.sun.jna.win32.W32APIOptions
+
+@Suppress("FunctionName")
+internal interface User32Extend : User32 {
+
+    fun SetWindowLong(hWnd: HWND, nIndex: Int, wndProc: WindowProc): LONG_PTR
+
+    fun SetWindowLongPtr(hWnd: HWND, nIndex: Int, wndProc: WindowProc): LONG_PTR
+
+    fun CallWindowProc(
+        proc: LONG_PTR,
+        hWnd: HWND,
+        uMsg: Int,
+        uParam: WPARAM,
+        lParam: LPARAM
+    ): LRESULT
+
+    fun GetSystemMetricsForDpi(nIndex: Int, dpi: UINT): Int
+
+    fun GetDpiForWindow(hWnd: HWND): UINT
+
+    fun ScreenToClient(hWnd: HWND, lpPoint: POINT): Boolean
+
+
+    companion object {
+
+        val instance by lazy {
+            runCatching {
+                Native.load(
+                    "user32",
+                    User32Extend::class.java,
+                    W32APIOptions.DEFAULT_OPTIONS
+                )
+            }
+                .onFailure { println("Could not load user32 library") }
+                .getOrNull()
+        }
+    }
+}
+
+internal fun User32Extend.setWindowLong(hWnd: HWND, nIndex: Int, procedure: WindowProcedure): LONG_PTR {
+    return if (Platform.is64Bit()) {
+        SetWindowLongPtr(hWnd, nIndex, procedure)
+    } else {
+        SetWindowLong(hWnd, nIndex, procedure)
+    }
+}
+
+internal fun User32.isWindowInMaximized(hWnd: HWND): Boolean {
+    val placement = WinUser.WINDOWPLACEMENT()
+    val result = GetWindowPlacement(hWnd, placement)
+        .booleanValue() && placement.showCmd == WinUser.SW_SHOWMAXIMIZED
+    placement.clear()
+    return result
+}
+
+internal fun User32.updateWindowStyle(hWnd: HWND, styleBlock: (oldStyle: Int) -> Int) {
+    val oldStyle = GetWindowLong(hWnd, WinUser.GWL_STYLE)
+    SetWindowLong(hWnd, WinUser.GWL_STYLE, styleBlock(oldStyle))
+}

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/WindowProcedure.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/WindowProcedure.kt
@@ -1,0 +1,5 @@
+package com.konyaco.fluent.gallery.jna.windows
+
+import com.sun.jna.platform.win32.WinUser.WindowProc
+
+typealias WindowProcedure = WindowProc

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/VersionHelper.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/VersionHelper.kt
@@ -1,0 +1,14 @@
+package com.konyaco.fluent.gallery.jna.windows.structure
+
+import com.sun.jna.platform.win32.Kernel32
+
+val windowsBuildNumber by lazy {
+    val buildNumber = Kernel32.INSTANCE.GetVersion().high.toInt()
+    buildNumber
+}
+
+fun isWindows10OrLater() = windowsBuildNumber >= 10240
+
+fun isWindows11OrLater() = windowsBuildNumber >= 22000
+
+fun isWindows1122H2OrLater() = windowsBuildNumber >= 22621

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/WinUserConst.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/WinUserConst.kt
@@ -2,6 +2,8 @@ package com.konyaco.fluent.gallery.jna.windows.structure
 
 object WinUserConst {
 
+    //calculate non client area size message
+    val WM_NCCALCSIZE = 0x0083
     // non client area hit test message
     val WM_NCHITTEST = 0x0084
     // mouse move message

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/WinUserConst.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/WinUserConst.kt
@@ -1,0 +1,42 @@
+package com.konyaco.fluent.gallery.jna.windows.structure
+
+object WinUserConst {
+
+    // non client area hit test message
+    val WM_NCHITTEST = 0x0084
+    // mouse move message
+    val WM_MOUSEMOVE = 0x0200
+    // left mouse button down message
+    val WM_LBUTTONDOWN = 0x0201
+    // left mouse button up message
+    val WM_LBUTTONUP = 0x0202
+    // non client area mouse move message
+    val WM_NCMOUSEMOVE = 0x00A0
+    // non client area left mouse down message
+    val WM_NCLBUTTONDOWN = 0x00A1
+    // non client area left mouse up message
+    val WM_NCLBUTTONUP = 0x00A2
+
+    /**
+     * [WM_NCHITTEST] Mouse Position Codes
+     */
+    // pass the hit test to parent window
+    internal val HTTRANSPANRENT = -1
+    // no hit test
+    internal val HTNOWHERE = 0
+    // client area
+    internal val HTCLIENT = 1
+    // title bar
+    internal val HTCAPTION = 2
+    // max button
+    internal val HTMAXBUTTON = 9
+    // window edges
+    internal val HTLEFT = 10
+    internal val HTRIGHT = 11
+    internal val HTTOP = 12
+    internal val HTTOPLEFT = 13
+    internal val HTTOPRIGHT = 14
+    internal val HTBOTTOM = 15
+    internal val HTBOTTOMLEFT = 16
+    internal val HTBOTTOMRIGHT = 17
+}

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/WindowMargins.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/WindowMargins.kt
@@ -1,0 +1,17 @@
+package com.konyaco.fluent.gallery.jna.windows.structure
+
+import com.sun.jna.Structure
+
+// See https://stackoverflow.com/q/62240901
+@Structure.FieldOrder(
+    "leftBorderWidth",
+    "rightBorderWidth",
+    "topBorderHeight",
+    "bottomBorderHeight"
+)
+data class WindowMargins(
+    @JvmField var leftBorderWidth: Int,
+    @JvmField var rightBorderWidth: Int,
+    @JvmField var topBorderHeight: Int,
+    @JvmField var bottomBorderHeight: Int
+) : Structure(), Structure.ByReference

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/window/LayoutHitTestOwner.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/window/LayoutHitTestOwner.kt
@@ -1,0 +1,167 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package com.konyaco.fluent.gallery.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.PointerInputModifierNode
+import androidx.compose.ui.scene.ComposeScene
+import androidx.compose.ui.util.fastForEachReversed
+import androidx.compose.ui.util.packFloats
+
+@OptIn(InternalComposeUiApi::class)
+@Composable
+fun rememberLayoutHitTestOwner(): LayoutHitTestOwner {
+    val scene = getLocalComposeScene()?.current ?: error("no compose scene")
+    return remember(scene) {
+        when(scene::class.qualifiedName) {
+            "androidx.compose.ui.scene.MultiLayerComposeSceneImpl" -> {
+                MultiLayerLayoutHitTestOwner(scene)
+            }
+            "androidx.compose.ui.scene.SingleLayerComposeSceneImpl" -> {
+                SingleLayerLayoutHitTestOwner(scene)
+            }
+            else -> error("unsupported compose scene")
+        }
+    }
+}
+
+@OptIn(InternalComposeUiApi::class)
+@Stable
+private fun getLocalComposeScene(): ProvidableCompositionLocal<ComposeScene>? {
+    val classLoader = ComposeScene::class.java.classLoader
+    val composeSceneClass = classLoader.loadClass("androidx.compose.ui.scene.ComposeScene_skikoKt")
+    val methodRef = composeSceneClass.getMethod("getLocalComposeScene")
+    methodRef.trySetAccessible()
+   return methodRef.invoke(null) as? ProvidableCompositionLocal<ComposeScene>
+}
+
+interface LayoutHitTestOwner {
+
+    fun hitTest(x: Float, y: Float): Boolean {
+        return false
+    }
+}
+
+/*
+* reflect implementation for compose 1.6
+ */
+internal abstract class ReflectLayoutHitTestOwner: LayoutHitTestOwner {
+
+    @OptIn(InternalComposeUiApi::class)
+    protected val classLoader = ComposeScene::class.java.classLoader!!
+
+    private val rootNodeOwnerOwnerField = classLoader.loadClass("androidx.compose.ui.node.RootNodeOwner")
+        .getDeclaredField("owner").apply {
+            trySetAccessible()
+        }
+
+    private val ownerRootField = classLoader.loadClass("androidx.compose.ui.node.Owner")
+        .getDeclaredMethod("getRoot").apply {
+            trySetAccessible()
+        }
+
+    private val hitTestResultClass = classLoader.loadClass("androidx.compose.ui.node.HitTestResult")
+
+    private val layoutNodeHitTestMethod = classLoader.loadClass("androidx.compose.ui.node.LayoutNode")
+        .declaredMethods.first { it.name.startsWith("hitTest-") && it.parameterCount == 4 }
+
+    protected fun getLayoutNode(rootNodeOwner: Any): Any {
+        val owner = rootNodeOwnerOwnerField.get(rootNodeOwner)
+        return ownerRootField.invoke(owner)
+    }
+
+    protected fun Any.layoutNodeHitTest(x: Float, y: Float): Boolean {
+        val result = hitTestResultClass.getDeclaredConstructor().newInstance() as List<Modifier.Node>
+        layoutNodeHitTestMethod.invoke(this, packFloats(x, y), result, false, true)
+        val lastNode = result.lastOrNull()
+        return lastNode is PointerInputModifierNode
+    }
+
+    protected class CopiedList<T>(
+        private val populate: (MutableList<T>) -> Unit
+    ) : MutableList<T> by mutableListOf() {
+        inline fun withCopy(
+            block: (List<T>) -> Unit
+        ) {
+            // In case of recursive calls, allocate new list
+            val copy = if (isEmpty()) this else mutableListOf()
+            populate(copy)
+            try {
+                block(copy)
+            } finally {
+                copy.clear()
+            }
+        }
+    }
+}
+
+@OptIn(InternalComposeUiApi::class)
+internal class SingleLayerLayoutHitTestOwner(scene: ComposeScene): ReflectLayoutHitTestOwner() {
+
+    private val sceneClass = classLoader.loadClass("androidx.compose.ui.scene.SingleLayerComposeSceneImpl")
+
+    private val mainOwnerRef = sceneClass.getDeclaredMethod("getMainOwner").let {
+        it.trySetAccessible()
+        it.invoke(scene)
+    }
+
+    override fun hitTest(x: Float, y: Float): Boolean {
+        return getLayoutNode(mainOwnerRef).layoutNodeHitTest(x, y)
+    }
+}
+
+@OptIn(InternalComposeUiApi::class)
+internal class MultiLayerLayoutHitTestOwner(private val scene: ComposeScene): ReflectLayoutHitTestOwner() {
+
+    private val sceneClass = classLoader.loadClass("androidx.compose.ui.scene.MultiLayerComposeSceneImpl")
+    private val layerClass = sceneClass.declaredClasses.first {it.name == "androidx.compose.ui.scene.MultiLayerComposeSceneImpl\$AttachedComposeSceneLayer" }
+
+    private val mainOwnerRef = sceneClass.getDeclaredField("mainOwner").let {
+        it.trySetAccessible()
+        it.get(scene)
+    }
+
+    private val layersRef = sceneClass.getDeclaredField("layers").let {
+        it.trySetAccessible()
+        it.get(scene)
+    } as MutableList<Any>
+
+    private val focusedLayerField = sceneClass.getDeclaredField("focusedLayer").apply {
+        trySetAccessible()
+    }
+
+    private val layerOwnerField = layerClass
+        .getDeclaredField("owner").apply {
+            trySetAccessible()
+        }
+
+    private val layerIsInBoundMethod = layerClass
+        .declaredMethods.first { it.name.startsWith("isInBounds") }.apply {
+            trySetAccessible()
+        }
+
+    private val _layers = CopiedList {
+        for (layer in layersRef) {
+            it.add(layer)
+        }
+    }
+
+    override fun hitTest(x: Float, y: Float): Boolean {
+        _layers.withCopy {
+            it.fastForEachReversed { layer ->
+                if (layerIsInBoundMethod.invoke(layer, packFloats(x, y)) == true) {
+                    return getLayoutNode(layerOwnerField.get(layer)).layoutNodeHitTest(x, y)
+                } else if (layer == focusedLayerField.get(scene)) {
+                    return false
+                }
+            }
+        }
+        return getLayoutNode(mainOwnerRef).layoutNodeHitTest(x, y)
+    }
+
+}

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/window/WindowsWindowFrame.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/window/WindowsWindowFrame.kt
@@ -1,15 +1,12 @@
 package com.konyaco.fluent.gallery.window
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandHorizontally
-import androidx.compose.animation.expandIn
 import androidx.compose.animation.shrinkHorizontally
-import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -36,7 +33,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -119,10 +115,7 @@ fun FrameWindowScope.WindowsWindowFrame(
             hitTest = { x, y ->
                 when {
                     maxButtonRect.value.contains(x, y) -> HTMAXBUTTON
-                    captionBarRect.value.contains(x, y) && !layoutHitTestOwner.hitTest(
-                        x,
-                        y
-                    ) -> HTCAPTION
+                    captionBarRect.value.contains(x, y) && !layoutHitTestOwner.hitTest(x, y) -> HTCAPTION
 
                     else -> HTCLIENT
                 }

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/window/WindowsWindowFrame.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/window/WindowsWindowFrame.kt
@@ -1,0 +1,432 @@
+package com.konyaco.fluent.gallery.window
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.shrinkOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.MutableWindowInsets
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.zIndex
+import com.konyaco.fluent.FluentTheme
+import com.konyaco.fluent.animation.FluentDuration
+import com.konyaco.fluent.animation.FluentEasing
+import com.konyaco.fluent.background.BackgroundSizing
+import com.konyaco.fluent.background.Layer
+import com.konyaco.fluent.component.SubtleButton
+import com.konyaco.fluent.component.Text
+import com.konyaco.fluent.gallery.jna.windows.ComposeWindowProcedure
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTCAPTION
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTCLIENT
+import com.konyaco.fluent.gallery.jna.windows.structure.WinUserConst.HTMAXBUTTON
+import com.konyaco.fluent.gallery.jna.windows.structure.isWindows11OrLater
+import com.konyaco.fluent.icons.Icons
+import com.konyaco.fluent.icons.regular.ArrowLeft
+import com.konyaco.fluent.icons.regular.Dismiss
+import com.konyaco.fluent.icons.regular.Square
+import com.konyaco.fluent.icons.regular.SquareMultiple
+import com.konyaco.fluent.icons.regular.Subtract
+import com.konyaco.fluent.scheme.PentaVisualScheme
+import com.konyaco.fluent.scheme.VisualStateScheme
+import com.konyaco.fluent.scheme.collectVisualState
+import com.mayakapps.compose.windowstyler.WindowBackdrop
+import com.mayakapps.compose.windowstyler.WindowStyle
+import com.mayakapps.compose.windowstyler.findSkiaLayer
+import com.sun.jna.platform.win32.User32
+import com.sun.jna.platform.win32.WinDef.HWND
+import com.sun.jna.platform.win32.WinUser
+import java.awt.Window
+import java.awt.event.WindowEvent
+import java.awt.event.WindowFocusListener
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalTextApi::class)
+@Composable
+fun FrameWindowScope.WindowsWindowFrame(
+    onCloseRequest: () -> Unit,
+    icon: Painter,
+    title: String,
+    state: WindowState,
+    backButtonVisible: Boolean = true,
+    backButtonEnabled: Boolean = false,
+    backButtonClick: () -> Unit = {},
+    content: @Composable () -> Unit
+) {
+    LaunchedEffect(window) {
+        window.findSkiaLayer()?.transparency = true
+    }
+    WindowStyle(
+        isDarkTheme = FluentTheme.colors.darkMode,
+        backdropType = when {
+            isWindows11OrLater() -> WindowBackdrop.Mica
+            else -> WindowBackdrop.Solid(FluentTheme.colors.background.mica.baseAlt)
+        }
+    )
+
+    val paddingInset = remember { MutableWindowInsets() }
+    val maxButtonRect = remember { mutableStateOf(Rect.Zero) }
+    val captionBarRect = remember { mutableStateOf(Rect.Zero) }
+    val layoutHitTestOwner = rememberLayoutHitTestOwner()
+
+    val procedure = remember(window) {
+        ComposeWindowProcedure(
+            window = window,
+            hitTest = { x, y ->
+                when {
+                    maxButtonRect.value.contains(x, y) -> HTMAXBUTTON
+                    captionBarRect.value.contains(x, y) && !layoutHitTestOwner.hitTest(
+                        x,
+                        y
+                    ) -> HTCAPTION
+
+                    else -> HTCLIENT
+                }
+            },
+            onWindowInsetUpdate = { paddingInset.insets = it }
+        )
+    }
+    Column(
+        modifier = Modifier.windowInsetsPadding(paddingInset)
+    ) {
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.height(48.dp)
+                .onGloballyPositioned { captionBarRect.value = it.boundsInWindow() }
+        ) {
+            AnimatedContent(
+                targetState = backButtonVisible,
+                transitionSpec = {
+                    ContentTransform(
+                        targetContentEnter = expandHorizontally(),
+                        initialContentExit = shrinkHorizontally(),
+                        sizeTransform = SizeTransform { _, _ ->
+                            tween(
+                                FluentDuration.ShortDuration,
+                                easing = FluentEasing.FastInvokeEasing
+                            )
+                        }
+                    )
+                },
+                modifier = Modifier.padding(start = 4.dp)
+            ) {
+                if (it) {
+                    val interaction = remember { MutableInteractionSource() }
+                    val isPressed by interaction.collectIsPressedAsState()
+                    val scaleX = animateFloatAsState(
+                        if (isPressed) {
+                            0.9f
+                        } else {
+                            1f
+                        }
+                    )
+                    SubtleButton(
+                        onClick = backButtonClick,
+                        disabled = !backButtonEnabled,
+                        interaction = interaction,
+                        iconOnly = true,
+                        modifier = Modifier.defaultMinSize(36.dp, 36.dp)
+                    ) {
+
+                        Text(
+                            text = CaptionButtonIcon.Back.glyph.toString(),
+                            fontFamily = if (!isWindows11OrLater()) {
+                                FontFamily("Segoe MDL2 Assets")
+                            } else {
+                                FontFamily("Segoe Fluent Icons")
+                            },
+                            modifier = Modifier.graphicsLayer {
+                                this.scaleX = scaleX.value
+                                translationX = (1f - scaleX.value) * 6.dp.toPx()
+                            },
+                            fontSize = 10.sp
+                        )
+                    }
+                } else {
+                    Spacer(modifier = Modifier.width(10.dp).height(36.dp))
+                }
+            }
+            Image(
+                painter = icon,
+                contentDescription = null,
+                modifier = Modifier.padding(start = 6.dp).size(16.dp)
+            )
+            Text(
+                text = title,
+                style = FluentTheme.typography.caption,
+                modifier = Modifier.padding(start = 16.dp)
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            window.CaptionButtonRow(
+                procedure.windowHandle,
+                state.placement == WindowPlacement.Maximized,
+                onCloseRequest = onCloseRequest,
+                onMaximizeButtonRectUpdate = {
+                    maxButtonRect.value = it
+                },
+                modifier = Modifier.align(Alignment.Top)
+            )
+        }
+        content()
+    }
+}
+
+@Composable
+fun Window.CaptionButtonRow(
+    windowHandle: HWND,
+    isMaximize: Boolean,
+    onCloseRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    onMaximizeButtonRectUpdate: (Rect) -> Unit
+) {
+    val isActive = remember { mutableStateOf(false) }
+    DisposableEffect(this) {
+        val listener = object : WindowFocusListener {
+            override fun windowGainedFocus(e: WindowEvent?) {
+                isActive.value = true
+            }
+
+            override fun windowLostFocus(e: WindowEvent?) {
+                isActive.value = false
+            }
+        }
+        addWindowFocusListener(listener)
+        onDispose {
+            removeWindowFocusListener(listener)
+        }
+    }
+    //Draw the caption button
+    Row(
+        modifier = modifier
+            .zIndex(1f)
+    ) {
+        CaptionButton(
+            onClick = {
+                User32.INSTANCE.CloseWindow(windowHandle)
+            },
+            icon = CaptionButtonIcon.Minimize,
+            isActive = isActive.value
+        )
+        CaptionButton(
+            onClick = {
+                if (isMaximize) {
+                    User32.INSTANCE.ShowWindow(
+                        windowHandle,
+                        WinUser.SW_RESTORE
+                    )
+                } else {
+                    User32.INSTANCE.ShowWindow(
+                        windowHandle,
+                        WinUser.SW_MAXIMIZE
+                    )
+                }
+            },
+            icon = if (isMaximize) {
+                CaptionButtonIcon.Restore
+            } else {
+                CaptionButtonIcon.Maximize
+            },
+            isActive = isActive.value,
+            modifier = Modifier.onGloballyPositioned {
+                onMaximizeButtonRectUpdate(it.boundsInWindow())
+            }
+        )
+        CaptionButton(
+            icon = CaptionButtonIcon.Close,
+            onClick = onCloseRequest,
+            isActive = isActive.value,
+            colors = CaptionButtonDefaults.closeColors()
+        )
+    }
+}
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+fun CaptionButton(
+    onClick: () -> Unit,
+    icon: CaptionButtonIcon,
+    isActive: Boolean,
+    modifier: Modifier = Modifier,
+    colors: VisualStateScheme<CaptionButtonColor> = CaptionButtonDefaults.defaultColors(),
+    interaction: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    val color = colors.schemeFor(interaction.collectVisualState(false))
+    Layer(
+        backgroundSizing = BackgroundSizing.OuterBorderEdge,
+        border = null,
+        color = if (isActive) {
+            color.background
+        } else {
+            color.inactiveBackground
+        },
+        contentColor = if (isActive) {
+            color.foreground
+        } else {
+            color.inactiveForeground
+        },
+        modifier = modifier.size(46.dp, 32.dp).clickable(
+            onClick = onClick,
+            interactionSource = interaction,
+            indication = null
+        ),
+        shape = RectangleShape
+    ) {
+        Text(
+            text = icon.glyph.toString(),
+            fontFamily = if (!isWindows11OrLater()) {
+                FontFamily("Segoe MDL2 Assets")
+            } else {
+                FontFamily("Segoe Fluent Icons")
+            },
+            textAlign = TextAlign.Center,
+            fontSize = 10.sp,
+            modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center)
+        )
+    }
+}
+
+object CaptionButtonDefaults {
+    @Composable
+    @Stable
+    fun defaultColors(
+        default: CaptionButtonColor = CaptionButtonColor(
+            background = FluentTheme.colors.subtleFill.transparent,
+            foreground = FluentTheme.colors.text.text.primary,
+            inactiveBackground = FluentTheme.colors.subtleFill.transparent,
+            inactiveForeground = FluentTheme.colors.text.text.disabled
+        ),
+        hovered: CaptionButtonColor = default.copy(
+            background = FluentTheme.colors.subtleFill.secondary,
+            inactiveBackground = FluentTheme.colors.subtleFill.secondary,
+            inactiveForeground = FluentTheme.colors.text.text.primary
+        ),
+        pressed: CaptionButtonColor = default.copy(
+            background = FluentTheme.colors.subtleFill.tertiary,
+            foreground = FluentTheme.colors.text.text.secondary,
+            inactiveBackground = FluentTheme.colors.subtleFill.tertiary,
+            inactiveForeground = FluentTheme.colors.text.text.tertiary
+        ),
+        disabled: CaptionButtonColor = default.copy(
+            foreground = FluentTheme.colors.text.text.disabled,
+        ),
+    ) = PentaVisualScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+
+    @Composable
+    @Stable
+    fun closeColors(
+        default: CaptionButtonColor = CaptionButtonColor(
+            background = FluentTheme.colors.subtleFill.transparent,
+            foreground = FluentTheme.colors.text.text.primary,
+            inactiveBackground = FluentTheme.colors.subtleFill.transparent,
+            inactiveForeground = FluentTheme.colors.text.text.disabled
+        ),
+        hovered: CaptionButtonColor = default.copy(
+            background = Color(0xFFC42B1C),
+            foreground = Color.White,
+            inactiveBackground = Color(0xFFC42B1C),
+            inactiveForeground = Color.White
+        ),
+        pressed: CaptionButtonColor = default.copy(
+            background = Color(0xFFC42B1C).copy(0.9f),
+            foreground = Color.White.copy(0.7f),
+            inactiveBackground = Color(0xFFC42B1C).copy(0.9f),
+            inactiveForeground = Color.White.copy(0.7f)
+        ),
+        disabled: CaptionButtonColor = default.copy(
+            foreground = FluentTheme.colors.text.text.disabled,
+        ),
+    ) = PentaVisualScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+}
+
+@Stable
+data class CaptionButtonColor(
+    val background: Color,
+    val foreground: Color,
+    val inactiveBackground: Color,
+    val inactiveForeground: Color
+)
+
+enum class CaptionButtonIcon(
+    val glyph: Char,
+    val imageVector: ImageVector
+) {
+    Minimize(
+        glyph = '\uE921',
+        imageVector = Icons.Default.Subtract
+    ),
+    Maximize(
+        glyph = '\uE922',
+        imageVector = Icons.Default.Square
+    ),
+    Restore(
+        glyph = '\uE923',
+        imageVector = Icons.Default.SquareMultiple
+    ),
+    Close(
+        glyph = '\uE8BB',
+        imageVector = Icons.Default.Dismiss
+    ),
+    Back(
+        glyph = '\uE830',
+        imageVector = Icons.Default.ArrowLeft
+    )
+}
+
+fun Rect.contains(x: Float, y: Float): Boolean {
+    return x >= left && x < right && y >= top && y < bottom
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidGradlePlugin = "8.3.2"
 androidBuildTools = "31.3.2"
 windowStyler = "0.3.3-SNAPSHOT"
 highlights = "0.8.0"
+jna = "5.14.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -24,6 +25,8 @@ android-tools-common = { module = "com.android.tools:common", version.ref = "and
 android-tools-sdk-common = { module = "com.android.tools:sdk-common", version.ref = "androidBuildTools" }
 window-styler = { module = "com.mayakapps.compose:window-styler", version.ref = "windowStyler" }
 highlights = { module = "dev.snipme:highlights", version.ref = "highlights" }
+jna-platform = { module = "net.java.dev.jna:jna-platform-jpms",  version.ref = "jna" }
+jna = { module = "net.java.dev.jna:jna-jpms",  version.ref = "jna" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
1. Android support navigate back.
2. Windows 11 has MicaEffect and new title bar experience which looks like UWP's ExtendToTitleBar API effects.
**reference**: 
[TransparentDecorationWindowProc](https://github.com/lhwdev/compose-window/blob/main/modules/platform/windows/src/main/kotlin/com/lhwdev/compose/window/platform/windows/TransparentDecorationWindowProc.kt)
[win32-window-custom-titlebar](https://github.com/grassator/win32-window-custom-titlebar)
[Missing animations when minimizing/maximizing/restoring undecorated window](https://github.com/JetBrains/compose-multiplatform/issues/3388#top)


https://github.com/Konyaco/compose-fluent-ui/assets/26089739/12891758-a1b1-46b5-bf8b-36dfa2652fdc

