### PR TITLE
[fluent] Add `Expander` and `ExpanderItem`.

### DIFF
--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/background/Layer.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/background/Layer.kt
@@ -105,7 +105,7 @@ fun Layer(
 @Composable
 fun Layer(
     modifier: Modifier = Modifier,
-    shape: Shape = RoundedCornerShape(size = 4.dp),
+    shape: Shape = FluentTheme.shapes.control,
     color: Color = FluentTheme.colors.background.layer.default,
     contentColor: Color = FluentTheme.colors.text.text.primary,
     border: BorderStroke? = BorderStroke(1.dp, FluentTheme.colors.stroke.card.default),

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/background/Layer.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/background/Layer.kt
@@ -89,6 +89,31 @@ fun Layer(
     elevation: Dp = 0.dp,
     content: @Composable () -> Unit
 ) {
+    Layer(
+        modifier = modifier,
+        shape = shape,
+        color = color,
+        contentColor = contentColor,
+        border = border,
+        backgroundSizing = backgroundSizing,
+        elevation = elevation,
+        clipContent = false,
+        content = content
+    )
+}
+
+@Composable
+fun Layer(
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(size = 4.dp),
+    color: Color = FluentTheme.colors.background.layer.default,
+    contentColor: Color = FluentTheme.colors.text.text.primary,
+    border: BorderStroke? = BorderStroke(1.dp, FluentTheme.colors.stroke.card.default),
+    backgroundSizing: BackgroundSizing,
+    clipContent: Boolean = false,
+    elevation: Dp = 0.dp,
+    content: @Composable () -> Unit
+) {
     ProvideTextStyle(FluentTheme.typography.body.copy(color = contentColor)) {
         CompositionLocalProvider(
             LocalContentColor provides contentColor,
@@ -100,7 +125,8 @@ fun Layer(
                     shape,
                     border,
                     backgroundSizing,
-                    color
+                    color,
+                    clipContent
                 ),
                 propagateMinConstraints = true
             ) {
@@ -116,7 +142,8 @@ private fun Modifier.layer(
     shape: Shape,
     border: BorderStroke?,
     backgroundSizing: BackgroundSizing,
-    color: Color
+    color: Color,
+    clipContent: Boolean
 ) = then(
     Modifier
         .elevation(elevation = elevation, shape = shape)
@@ -130,6 +157,7 @@ private fun Modifier.layer(
                     }
                 Modifier.border(border, shape)
                     .background(color, backgroundShape)
+                    .then(if (clipContent) Modifier.clip(backgroundShape) else Modifier)
             } else {
                 Modifier.background(color, shape)
             }
@@ -142,7 +170,7 @@ private fun Modifier.layer(
  */
 @Immutable
 @JvmInline
-private value class BackgroundPaddingShape(private val borderShape: CornerBasedShape) : Shape {
+internal value class BackgroundPaddingShape(private val borderShape: CornerBasedShape) : Shape {
 
     override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
         return with(density) {

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Expander.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Expander.kt
@@ -1,0 +1,305 @@
+package com.konyaco.fluent.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import com.konyaco.fluent.FluentTheme
+import com.konyaco.fluent.ProvideTextStyle
+import com.konyaco.fluent.animation.FluentDuration
+import com.konyaco.fluent.animation.FluentEasing
+import com.konyaco.fluent.background.BackgroundSizing
+import com.konyaco.fluent.background.Layer
+import com.konyaco.fluent.icons.Icons
+import com.konyaco.fluent.icons.regular.ChevronDown
+import com.konyaco.fluent.scheme.PentaVisualScheme
+import com.konyaco.fluent.scheme.VisualStateScheme
+import com.konyaco.fluent.scheme.collectVisualState
+import com.konyaco.fluent.surface.Card
+import com.konyaco.fluent.surface.CardColor
+
+@Composable
+fun Expander(
+    expanded: Boolean,
+    onExpandedChanged: (Boolean) -> Unit,
+    heading: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource? = null,
+    shape: Shape = RoundedCornerShape(4.dp),
+    icon: (@Composable () -> Unit)? = {},
+    caption: @Composable () -> Unit = {},
+    training: @Composable () -> Unit = {},
+    expandContent: (@Composable ColumnScope.() -> Unit) = {},
+) {
+    Layer(
+        backgroundSizing = BackgroundSizing.InnerBorderEdge,
+        modifier = modifier,
+        color = Color.Transparent,
+        shape = shape,
+        clipContent = true
+    ) {
+        Column {
+            val targetInteractionSource =
+                interactionSource ?: remember { MutableInteractionSource() }
+
+            ExpanderItemContent(
+                icon = icon,
+                heading = heading,
+                caption = caption,
+                training = training,
+                dropdown = {
+                    SubtleButton(
+                        interaction = targetInteractionSource,
+                        onClick = { onExpandedChanged(!expanded) },
+                        content = {
+                            val degrees by animateFloatAsState(if (expanded) 180f else 0f)
+                            Icon(
+                                imageVector = Icons.Default.ChevronDown,
+                                contentDescription = null,
+                                modifier = Modifier.graphicsLayer { rotationZ = degrees }
+                            )
+                        },
+                        iconOnly = true,
+                        disabled = !enabled
+                    )
+                },
+                modifier = Modifier.padding(top = 1.dp)
+                    .heightIn(ExpanderHeaderHeight)
+                    .background(FluentTheme.colors.background.card.default)
+                    .clickable(
+                        interactionSource = targetInteractionSource,
+                        indication = null,
+                        onClick = { onExpandedChanged(!expanded) },
+                        enabled = enabled
+                    )
+            )
+            ExpanderItemSeparator(color = FluentTheme.colors.stroke.card.default)
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically(
+                    tween(FluentDuration.MediumDuration, 0, FluentEasing.FastInvokeEasing)
+                ),
+                exit = shrinkVertically(
+                    tween(FluentDuration.QuickDuration, 0, FluentEasing.SoftDismissEasing)
+                )
+            ) {
+                Column(modifier = Modifier.padding(bottom = 1.dp)) {
+                    expandContent()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ExpanderItem(
+    heading: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    color: Color = FluentTheme.colors.background.card.secondary,
+    icon: (@Composable () -> Unit)? = {},
+    caption: @Composable () -> Unit = {},
+    training: @Composable () -> Unit = {},
+    dropdown: (@Composable () -> Unit)? = {}
+) {
+    ExpanderItemContent(
+        icon = icon,
+        heading = heading,
+        caption = caption,
+        training = training,
+        dropdown = dropdown,
+        modifier = modifier.background(color)
+    )
+}
+
+@Composable
+fun CardExpanderItem(
+    onClick: () -> Unit,
+    heading: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(4.dp),
+    enabled: Boolean = true,
+    colors: VisualStateScheme<CardColor> = ExpanderDefaults.cardExpanderItemColors(),
+    captionColors: VisualStateScheme<Color> = PentaVisualScheme(
+        default = FluentTheme.colors.text.text.secondary,
+        hovered = FluentTheme.colors.text.text.secondary,
+        pressed = FluentTheme.colors.text.text.tertiary,
+        disabled = FluentTheme.colors.text.text.disabled
+    ),
+    interactionSource: MutableInteractionSource? = null,
+    icon: (@Composable () -> Unit)? = {},
+    caption: @Composable () -> Unit = {},
+    training: @Composable () -> Unit = {},
+    dropdown: (@Composable () -> Unit)? = null,
+) {
+    val targetInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+    val captionTextColor = captionColors.schemeFor(targetInteractionSource.collectVisualState(!enabled))
+    Card(
+        onClick = onClick,
+        modifier = modifier,
+        disabled = !enabled,
+        cardColors = colors,
+        shape = shape,
+        interactionSource = targetInteractionSource
+    ) {
+        ExpanderItemContent(
+            icon = icon,
+            heading = heading,
+            caption = caption,
+            training = training,
+            dropdown = dropdown,
+            modifier = Modifier.heightIn(ExpanderHeaderHeight),
+            captionTextColor = captionTextColor
+        )
+    }
+}
+
+@Composable
+fun CardExpanderItem(
+    heading: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(4.dp),
+    color: Color = FluentTheme.colors.background.card.default,
+    contentColor: Color = FluentTheme.colors.text.text.primary,
+    captionTextColor: Color = FluentTheme.colors.text.text.secondary,
+    icon: (@Composable () -> Unit)? = {},
+    caption: @Composable () -> Unit = {},
+    training: @Composable () -> Unit = {},
+    dropdown: (@Composable () -> Unit)? = null
+) {
+    Layer(
+        modifier = modifier,
+        backgroundSizing = BackgroundSizing.InnerBorderEdge,
+        shape = shape,
+        color = color,
+        contentColor = contentColor
+    ) {
+        ExpanderItemContent(
+            icon = icon,
+            heading = heading,
+            caption = caption,
+            training = training,
+            dropdown = dropdown,
+            modifier = Modifier.heightIn(ExpanderHeaderHeight),
+            captionTextColor = captionTextColor
+        )
+    }
+}
+
+@Composable
+fun ExpanderItemSeparator(
+    modifier: Modifier = Modifier,
+    color: Color = FluentTheme.colors.stroke.divider.default
+) {
+    Box(
+        modifier = modifier.fillMaxWidth().height(1.dp).background(color)
+    )
+}
+
+object ExpanderDefaults {
+
+    @Stable
+    @Composable
+    fun cardExpanderItemColors(
+        default: CardColor = CardColor(
+            fillColor = FluentTheme.colors.background.card.default,
+            contentColor = FluentTheme.colors.text.text.primary,
+            borderBrush = SolidColor(FluentTheme.colors.stroke.card.default)
+        ),
+        hovered: CardColor = default.copy(
+            fillColor = FluentTheme.colors.control.secondary,
+            borderBrush = FluentTheme.colors.borders.control
+        ),
+        pressed: CardColor = CardColor(
+            fillColor = FluentTheme.colors.control.tertiary,
+            contentColor = FluentTheme.colors.text.text.secondary,
+            borderBrush = SolidColor(FluentTheme.colors.stroke.control.default)
+        ),
+        disabled: CardColor = pressed.copy(
+            fillColor = FluentTheme.colors.background.card.default,
+            contentColor = FluentTheme.colors.text.text.disabled,
+            borderBrush = SolidColor(FluentTheme.colors.stroke.card.default)
+        )
+    ) = PentaVisualScheme(default, hovered, pressed, disabled)
+}
+
+@Composable
+internal fun ExpanderItemContent(
+    modifier: Modifier = Modifier,
+    captionTextColor: Color = FluentTheme.colors.text.text.secondary,
+    icon: (@Composable () -> Unit)? = {},
+    heading: @Composable () -> Unit = {},
+    caption: @Composable () -> Unit = {},
+    training: @Composable () -> Unit = {},
+    dropdown: (@Composable () -> Unit)? = {}
+) {
+    Row(
+        modifier = Modifier.then(modifier)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (icon != null) {
+            Box(
+                modifier = Modifier.widthIn(48.dp).defaultMinSize(16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                icon()
+            }
+        } else {
+            Spacer(modifier = Modifier.width(16.dp))
+        }
+        Column(modifier = Modifier.padding(vertical = 13.dp)) {
+            heading()
+            ProvideTextStyle(FluentTheme.typography.caption.copy(captionTextColor)) {
+                caption()
+            }
+        }
+        Spacer(modifier = Modifier.weight(1f).height(1.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(end = 8.dp)
+        ) {
+            training()
+            if (dropdown != null) {
+                Box(
+                    modifier = Modifier.padding(start = 4.dp).defaultMinSize(32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    dropdown()
+                }
+            } else {
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+        }
+    }
+}
+
+private val ExpanderHeaderHeight = 62.dp

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Expander.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Expander.kt
@@ -57,7 +57,7 @@ fun Expander(
     shape: Shape = RoundedCornerShape(4.dp),
     icon: (@Composable () -> Unit)? = {},
     caption: @Composable () -> Unit = {},
-    training: @Composable () -> Unit = {},
+    trailing: @Composable () -> Unit = {},
     expandContent: (@Composable ColumnScope.() -> Unit) = {},
 ) {
     Layer(
@@ -75,7 +75,7 @@ fun Expander(
                 icon = icon,
                 heading = heading,
                 caption = caption,
-                training = training,
+                trailing = trailing,
                 dropdown = {
                     SubtleButton(
                         interaction = targetInteractionSource,
@@ -127,14 +127,14 @@ fun ExpanderItem(
     color: Color = FluentTheme.colors.background.card.secondary,
     icon: (@Composable () -> Unit)? = {},
     caption: @Composable () -> Unit = {},
-    training: @Composable () -> Unit = {},
+    trailing: @Composable () -> Unit = {},
     dropdown: (@Composable () -> Unit)? = {}
 ) {
     ExpanderItemContent(
         icon = icon,
         heading = heading,
         caption = caption,
-        training = training,
+        trailing = trailing,
         dropdown = dropdown,
         modifier = modifier.background(color)
     )
@@ -157,7 +157,7 @@ fun CardExpanderItem(
     interactionSource: MutableInteractionSource? = null,
     icon: (@Composable () -> Unit)? = {},
     caption: @Composable () -> Unit = {},
-    training: @Composable () -> Unit = {},
+    trailing: @Composable () -> Unit = {},
     dropdown: (@Composable () -> Unit)? = null,
 ) {
     val targetInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
@@ -174,7 +174,7 @@ fun CardExpanderItem(
             icon = icon,
             heading = heading,
             caption = caption,
-            training = training,
+            trailing = trailing,
             dropdown = dropdown,
             modifier = Modifier.heightIn(ExpanderHeaderHeight),
             captionTextColor = captionTextColor
@@ -192,7 +192,7 @@ fun CardExpanderItem(
     captionTextColor: Color = FluentTheme.colors.text.text.secondary,
     icon: (@Composable () -> Unit)? = {},
     caption: @Composable () -> Unit = {},
-    training: @Composable () -> Unit = {},
+    trailing: @Composable () -> Unit = {},
     dropdown: (@Composable () -> Unit)? = null
 ) {
     Layer(
@@ -206,7 +206,7 @@ fun CardExpanderItem(
             icon = icon,
             heading = heading,
             caption = caption,
-            training = training,
+            trailing = trailing,
             dropdown = dropdown,
             modifier = Modifier.heightIn(ExpanderHeaderHeight),
             captionTextColor = captionTextColor
@@ -258,7 +258,7 @@ internal fun ExpanderItemContent(
     icon: (@Composable () -> Unit)? = {},
     heading: @Composable () -> Unit = {},
     caption: @Composable () -> Unit = {},
-    training: @Composable () -> Unit = {},
+    trailing: @Composable () -> Unit = {},
     dropdown: (@Composable () -> Unit)? = {}
 ) {
     Row(
@@ -287,7 +287,7 @@ internal fun ExpanderItemContent(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(end = 8.dp)
         ) {
-            training()
+            trailing()
             if (dropdown != null) {
                 Box(
                     modifier = Modifier.padding(start = 4.dp).defaultMinSize(32.dp),

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Expander.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/Expander.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -54,7 +53,7 @@ fun Expander(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource? = null,
-    shape: Shape = RoundedCornerShape(4.dp),
+    shape: Shape = FluentTheme.shapes.control,
     icon: (@Composable () -> Unit)? = {},
     caption: @Composable () -> Unit = {},
     trailing: @Composable () -> Unit = {},
@@ -145,7 +144,7 @@ fun CardExpanderItem(
     onClick: () -> Unit,
     heading: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    shape: Shape = RoundedCornerShape(4.dp),
+    shape: Shape = FluentTheme.shapes.control,
     enabled: Boolean = true,
     colors: VisualStateScheme<CardColor> = ExpanderDefaults.cardExpanderItemColors(),
     captionColors: VisualStateScheme<Color> = PentaVisualScheme(
@@ -186,7 +185,7 @@ fun CardExpanderItem(
 fun CardExpanderItem(
     heading: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    shape: Shape = RoundedCornerShape(4.dp),
+    shape: Shape = FluentTheme.shapes.control,
     color: Color = FluentTheme.colors.background.card.default,
     contentColor: Color = FluentTheme.colors.text.text.primary,
     captionTextColor: Color = FluentTheme.colors.text.text.secondary,

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/GallerySection.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/GallerySection.kt
@@ -176,7 +176,7 @@ fun GallerySection(
                             icon = null,
                             heading = { Text("Kotlin", style = FluentTheme.typography.bodyStrong) },
                             color = Color.Transparent,
-                            training = { CopyButton(sourceCode, modifier = Modifier) },
+                            trailing = { CopyButton(sourceCode, modifier = Modifier) },
                             dropdown = null
                         )
                         val scrollState = rememberScrollState()

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/GallerySection.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/component/GallerySection.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.konyaco.fluent.Colors
 import com.konyaco.fluent.ExperimentalFluentApi
@@ -43,13 +43,14 @@ import com.konyaco.fluent.animation.FluentDuration
 import com.konyaco.fluent.animation.FluentEasing
 import com.konyaco.fluent.background.BackgroundSizing
 import com.konyaco.fluent.background.Layer
+import com.konyaco.fluent.component.ExpanderItem
+import com.konyaco.fluent.component.ExpanderItemSeparator
 import com.konyaco.fluent.component.Icon
 import com.konyaco.fluent.component.Scrollbar
 import com.konyaco.fluent.component.SubtleButton
 import com.konyaco.fluent.component.Text
 import com.konyaco.fluent.icons.Icons
 import com.konyaco.fluent.icons.regular.ChevronDown
-import com.konyaco.fluent.surface.Card
 
 @OptIn(ExperimentalFluentApi::class)
 @Composable
@@ -63,122 +64,136 @@ fun GallerySection(
     content: @Composable BoxScope.() -> Unit,
 ) {
     Column(modifier) {
+
         Text(title, style = FluentTheme.typography.bodyStrong)
         Spacer(Modifier.height(16.dp))
-        FluentThemeConfiguration(colors = colors) {
-            Layer(
-                modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-                shape = RoundedCornerShape(
-                    topStart = FluentTheme.cornerRadius.overlay,
-                    topEnd = FluentTheme.cornerRadius.overlay
-                ),
-                color = FluentTheme.colors.background.solid.base,
-                backgroundSizing = BackgroundSizing.OuterBorderEdge
-            ) {
-                Row(
-                    modifier = Modifier.height(IntrinsicSize.Max)
-                ) {
+
+        Layer(
+            modifier = Modifier.fillMaxWidth(),
+            backgroundSizing = BackgroundSizing.InnerBorderEdge,
+            shape = FluentTheme.shapes.overlay,
+            clipContent = true,
+            color = Color.Transparent
+        ) {
+            Column {
+                FluentThemeConfiguration(colors = colors) {
                     Box(
-                        modifier = Modifier.weight(1f)
-                            .defaultMinSize(minHeight = 100.dp)
-                            .padding(16.dp),
-                        contentAlignment = Alignment.CenterStart,
-                        content = content
-                    )
-                    if (output != null) {
-                        Box(
-                            modifier = Modifier.fillMaxHeight()
-                                .padding(0.dp, 12.dp, 12.dp, 12.dp)
-                                .padding(16.dp)
+                        modifier = Modifier
+                            .background(FluentTheme.colors.background.solid.base)
+                            .fillMaxWidth()
+                            .wrapContentHeight(),
+                    ) {
+                        Row(
+                            modifier = Modifier.height(IntrinsicSize.Max)
                         ) {
-                            Column(
-                                verticalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                Text("Output:")
-                                output()
+                            Box(
+                                modifier = Modifier.weight(1f)
+                                    .defaultMinSize(minHeight = 100.dp)
+                                    .padding(16.dp),
+                                contentAlignment = Alignment.CenterStart,
+                                content = content
+                            )
+                            if (output != null) {
+                                Box(
+                                    modifier = Modifier.fillMaxHeight()
+                                        .padding(0.dp, 12.dp, 12.dp, 12.dp)
+                                        .padding(16.dp)
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        Text("Output:")
+                                        output()
+                                    }
+                                }
+                            }
+                            if (options != null) {
+                                Spacer(
+                                    modifier = Modifier.padding(vertical = 1.dp)
+                                        .fillMaxHeight()
+                                        .width(1.dp)
+                                        .background(FluentTheme.colors.stroke.divider.default)
+                                )
+                                Column(
+                                    modifier = Modifier.fillMaxHeight()
+                                        .background(FluentTheme.colors.background.card.default)
+                                        .padding(16.dp)
+                                        .width(IntrinsicSize.Max),
+                                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    options()
+                                }
                             }
                         }
                     }
-                    if (options != null) {
-                        Spacer(
-                            modifier = Modifier.padding(vertical = 1.dp)
-                                .fillMaxHeight()
-                                .width(1.dp)
-                                .background(FluentTheme.colors.stroke.divider.default)
-                        )
-                        Column(
-                            modifier = Modifier.fillMaxHeight()
-                                .background(FluentTheme.colors.background.card.default)
-                                .padding(16.dp)
-                                .width(IntrinsicSize.Max),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                }
+                ExpanderItemSeparator(color = FluentTheme.colors.stroke.card.default)
+
+                var sourceCodeExpanded by remember { mutableStateOf(false) }
+                val interactionSource = remember { MutableInteractionSource() }
+
+                ExpanderItem(
+                    icon = null,
+                    heading = { Text("Source Code") },
+                    dropdown = {
+                        SubtleButton(
+                            onClick = { sourceCodeExpanded = !sourceCodeExpanded },
+                            interaction = interactionSource,
+                            iconOnly = true
                         ) {
-                            options()
+                            Icon(
+                                modifier = Modifier.rotate(
+                                    animateFloatAsState(
+                                        if (sourceCodeExpanded) 180f else 0f,
+                                    ).value
+                                ),
+                                imageVector = Icons.Default.ChevronDown,
+                                contentDescription = "Expand source code"
+                            )
                         }
-                    }
-                }
-            }
-        }
-
-        var sourceCodeExpanded by remember { mutableStateOf(false) }
-
-        val interactionSource = remember { MutableInteractionSource() }
-        Card(
-            modifier = Modifier.fillMaxWidth()
-                .clickable(interactionSource = interactionSource, indication = null, onClick = {
-                    sourceCodeExpanded = !sourceCodeExpanded
-                }),
-            shape = RoundedCornerShape(
-                bottomEnd = if (sourceCodeExpanded) 0.dp else FluentTheme.cornerRadius.overlay,
-                bottomStart = if (sourceCodeExpanded) 0.dp else FluentTheme.cornerRadius.overlay
-            )
-        ) {
-            Row(Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                Text(modifier = Modifier.padding(start = 8.dp).weight(1f), text = "Source Code")
-                SubtleButton(
-                    onClick = { sourceCodeExpanded = !sourceCodeExpanded },
-                    interaction = interactionSource,
-                    iconOnly = true
-                ) {
-                    Icon(
-                        modifier = Modifier.rotate(
-                            animateFloatAsState(
-                                if (sourceCodeExpanded) 180f else 0f,
-                            ).value
-                        ),
-                        imageVector = Icons.Default.ChevronDown,
-                        contentDescription = "Expand source code"
+                    },
+                    color = FluentTheme.colors.background.card.default,
+                    modifier = Modifier.clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = { sourceCodeExpanded = !sourceCodeExpanded }
                     )
-                }
-            }
-        }
-        AnimatedVisibility(
-            visible = sourceCodeExpanded,
-            enter = expandVertically(
-                tween(FluentDuration.MediumDuration, 0, FluentEasing.FastInvokeEasing)
-            ),
-            exit = shrinkVertically(
-                tween(FluentDuration.QuickDuration, 0, FluentEasing.SoftDismissEasing)
-            )
-        ) {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(
-                    bottomEnd = FluentTheme.cornerRadius.overlay,
-                    bottomStart = FluentTheme.cornerRadius.overlay
                 )
-            ) {
-                Column(Modifier.padding(16.dp, 12.dp)) {
-                    Text("Kotlin", style = FluentTheme.typography.bodyStrong)
-                    Spacer(Modifier.height(12.dp))
-                    val scrollState = rememberScrollState()
-                    Box(Modifier.fillMaxWidth().wrapContentHeight()) {
-                        SourceCode(
-                            modifier = Modifier.horizontalScroll(scrollState),
-                            code = sourceCode
+                if (sourceCodeExpanded) {
+                    ExpanderItemSeparator(color = FluentTheme.colors.stroke.card.default)
+                }
+                AnimatedVisibility(
+                    visible = sourceCodeExpanded,
+                    enter = expandVertically(
+                        tween(FluentDuration.MediumDuration, 0, FluentEasing.FastInvokeEasing)
+                    ),
+                    exit = shrinkVertically(
+                        tween(FluentDuration.QuickDuration, 0, FluentEasing.SoftDismissEasing)
+                    )
+                ) {
+                    Column(Modifier.background(FluentTheme.colors.background.card.secondary).padding(bottom = 12.dp)) {
+                        ExpanderItem(
+                            icon = null,
+                            heading = { Text("Kotlin", style = FluentTheme.typography.bodyStrong) },
+                            color = Color.Transparent,
+                            training = { CopyButton(sourceCode, modifier = Modifier) },
+                            dropdown = null
                         )
-                        Box(Modifier.fillMaxWidth().align(Alignment.BottomCenter)) {
-                            Scrollbar(modifier = Modifier.fillMaxWidth(), isVertical = false, adapter = com.konyaco.fluent.component.rememberScrollbarAdapter(scrollState))
+                        val scrollState = rememberScrollState()
+                        Box(Modifier.padding(horizontal = 16.dp).fillMaxWidth().wrapContentHeight()) {
+                            SourceCode(
+                                modifier = Modifier.horizontalScroll(scrollState),
+                                code = sourceCode
+                            )
+                            Box(Modifier.fillMaxWidth().align(Alignment.BottomCenter)) {
+                                Scrollbar(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    isVertical = false,
+                                    adapter = com.konyaco.fluent.component.rememberScrollbarAdapter(
+                                        scrollState
+                                    )
+                                )
+                            }
                         }
                     }
                 }

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/collections/ExpanderScreen.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/collections/ExpanderScreen.kt
@@ -71,7 +71,7 @@ private fun ExpanderSample() {
         heading = { Text("Power button functionality") },
         caption = { Text("Adjust what yor power buttons control") },
         icon = { Icon(Icons.Default.Power, null) },
-        training = {
+        trailing = {
             val checked = remember { mutableStateOf(true) }
             Switcher(
                 checked = checked.value,
@@ -83,12 +83,12 @@ private fun ExpanderSample() {
     ) {
         ExpanderItem(
             heading = { Text("When I press the power button on battery") },
-            training = { DropDownButton(onClick = {}, content = { Text("Sleep") }) }
+            trailing = { DropDownButton(onClick = {}, content = { Text("Sleep") }) }
         )
         ExpanderItemSeparator()
         ExpanderItem(
             heading = { Text("When I press the power button when plugged in") },
-            training = { DropDownButton(onClick = {}, content = { Text("Sleep") }) }
+            trailing = { DropDownButton(onClick = {}, content = { Text("Sleep") }) }
         )
     }
 }
@@ -103,7 +103,7 @@ private fun ExpanderSampleWithoutIcon() {
         heading = { Text("Power button functionality") },
         caption = { Text("Adjust what yor power buttons control") },
         icon = null,
-        training = {
+        trailing = {
             val checked = remember { mutableStateOf(true) }
             Switcher(
                 checked = checked.value,
@@ -115,7 +115,7 @@ private fun ExpanderSampleWithoutIcon() {
     ) {
         ExpanderItem(
             heading = { Text("When I press the power button on battery") },
-            training = { DropDownButton(onClick = {}, content = { Text("Sleep") }) },
+            trailing = { DropDownButton(onClick = {}, content = { Text("Sleep") }) },
             icon = null
         )
     }
@@ -128,7 +128,7 @@ private fun CardExpanderItemSample() {
         heading = { Text("Power button functionality") },
         caption = { Text("Adjust what yor power buttons control") },
         icon = { Icon(Icons.Default.Power, null) },
-        training = {
+        trailing = {
             val checked = remember { mutableStateOf(true) }
             Switcher(
                 checked = checked.value,

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/collections/ExpanderScreen.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/collections/ExpanderScreen.kt
@@ -1,0 +1,154 @@
+package com.konyaco.fluent.gallery.screen.collections
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.konyaco.fluent.component.CardExpanderItem
+import com.konyaco.fluent.component.CheckBox
+import com.konyaco.fluent.component.DropDownButton
+import com.konyaco.fluent.component.Expander
+import com.konyaco.fluent.component.ExpanderItem
+import com.konyaco.fluent.component.ExpanderItemSeparator
+import com.konyaco.fluent.component.Icon
+import com.konyaco.fluent.component.Switcher
+import com.konyaco.fluent.component.Text
+import com.konyaco.fluent.gallery.annotation.Component
+import com.konyaco.fluent.gallery.annotation.Sample
+import com.konyaco.fluent.gallery.component.ComponentPagePath
+import com.konyaco.fluent.gallery.component.GalleryPage
+import com.konyaco.fluent.icons.Icons
+import com.konyaco.fluent.icons.regular.ChevronRight
+import com.konyaco.fluent.icons.regular.Power
+import com.konyaco.fluent.source.generated.FluentSourceFile
+
+@Component(description = "Control that displays a header and a collapsible content area.")
+@Composable
+fun ExpanderScreen() {
+    GalleryPage(
+        title = "Expander",
+        description = "An expander control that can be used to create Windows 11 style settings experiences.",
+        componentPath = FluentSourceFile.Expander,
+        galleryPath = ComponentPagePath.ExpanderScreen
+    ) {
+        Section(
+            title = "Basic Expander",
+            sourceCode = sourceCodeOfExpanderSample,
+            content = { ExpanderSample() }
+        )
+        Section(
+            title = "Expander without icon",
+            sourceCode = sourceCodeOfExpanderSampleWithoutIcon,
+            content = { ExpanderSampleWithoutIcon() }
+        )
+        Section(
+            title = "Card Expander Item",
+            sourceCode = sourceCodeOfCardExpanderItemSample,
+            content = { CardExpanderItemSample() }
+        )
+        val enabled = remember { mutableStateOf(true) }
+        Section(
+            title = "Clickable Card Expander Item",
+            sourceCode = sourceCodeOfClickableCardExpanderItemSample,
+            content = { ClickableCardExpanderItemSample(enabled = enabled.value) },
+            options = {
+                CheckBox(
+                    checked = enabled.value,
+                    onCheckStateChange = { enabled.value = it },
+                    label = "Enabled"
+                )
+            }
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun ExpanderSample() {
+    val expanded = remember { mutableStateOf(false) }
+    Expander(
+        expanded = expanded.value,
+        onExpandedChanged = { expanded.value = it },
+        heading = { Text("Power button functionality") },
+        caption = { Text("Adjust what yor power buttons control") },
+        icon = { Icon(Icons.Default.Power, null) },
+        training = {
+            val checked = remember { mutableStateOf(true) }
+            Switcher(
+                checked = checked.value,
+                { checked.value = it },
+                textBefore = true,
+                text = if (checked.value) "On" else "Off"
+            )
+        }
+    ) {
+        ExpanderItem(
+            heading = { Text("When I press the power button on battery") },
+            training = { DropDownButton(onClick = {}, content = { Text("Sleep") }) }
+        )
+        ExpanderItemSeparator()
+        ExpanderItem(
+            heading = { Text("When I press the power button when plugged in") },
+            training = { DropDownButton(onClick = {}, content = { Text("Sleep") }) }
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun ExpanderSampleWithoutIcon() {
+    val expanded = remember { mutableStateOf(false) }
+    Expander(
+        expanded = expanded.value,
+        onExpandedChanged = { expanded.value = it },
+        heading = { Text("Power button functionality") },
+        caption = { Text("Adjust what yor power buttons control") },
+        icon = null,
+        training = {
+            val checked = remember { mutableStateOf(true) }
+            Switcher(
+                checked = checked.value,
+                { checked.value = it },
+                textBefore = true,
+                text = if (checked.value) "On" else "Off"
+            )
+        }
+    ) {
+        ExpanderItem(
+            heading = { Text("When I press the power button on battery") },
+            training = { DropDownButton(onClick = {}, content = { Text("Sleep") }) },
+            icon = null
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun CardExpanderItemSample() {
+    CardExpanderItem(
+        heading = { Text("Power button functionality") },
+        caption = { Text("Adjust what yor power buttons control") },
+        icon = { Icon(Icons.Default.Power, null) },
+        training = {
+            val checked = remember { mutableStateOf(true) }
+            Switcher(
+                checked = checked.value,
+                { checked.value = it },
+                textBefore = true,
+                text = if (checked.value) "On" else "Off"
+            )
+        }
+    )
+}
+
+@Sample
+@Composable
+private fun ClickableCardExpanderItemSample(enabled: Boolean = true) {
+    CardExpanderItem(
+        heading = { Text("Power button functionality") },
+        caption = { Text("Adjust what yor power buttons control") },
+        icon = { Icon(Icons.Default.Power, null) },
+        dropdown = { Icon(Icons.Default.ChevronRight, null) },
+        onClick = {},
+        enabled = enabled
+    )
+}


### PR DESCRIPTION
## Components
1. `Expander`
2. `ExpanderItem`
3. `ExpanderItemSeparator`
4. `CardExpanderItem`
## Basic Usage
```Kotlin
val expanded = remember { mutableStateOf(false) }
Expander(
    expanded = expanded.value,
    onExpandedChanged = { expanded.value = it },
    heading = { Text("Power button functionality") },
    caption = { Text("Adjust what yor power buttons control") },
    icon = { Icon(Icons.Default.Power, null) },
    training = {
        val checked = remember { mutableStateOf(true) }
        Switcher(
            checked = checked.value,
            { checked.value = it },
            textBefore = true,
            text = if (checked.value) "On" else "Off"
        )
    }
) {
    ExpanderItem(
        heading = { Text("When I press the power button on battery") },
        training = { DropDownButton(onClick = {}, content = { Text("Sleep") }) }
    )
    ExpanderItemSeparator()
    ExpanderItem(
        heading = { Text("When I press the power button when plugged in") },
        training = { DropDownButton(onClick = {}, content = { Text("Sleep") }) }
    )
}
```

## Screenshot
![image](https://github.com/Konyaco/compose-fluent-ui/assets/26089739/bb6fb586-7dae-4804-944e-ddd2f92d7002)
