### PR TITLE
[fluent] `Elevation` support

### DIFF
--- a/fluent/src/androidMain/kotlin/com/konyaco/fluent/background/Elevation.android.kt
+++ b/fluent/src/androidMain/kotlin/com/konyaco/fluent/background/Elevation.android.kt
@@ -1,0 +1,13 @@
+package com.konyaco.fluent.background
+
+import android.graphics.BlurMaskFilter
+import android.os.Build
+import androidx.compose.ui.graphics.Paint
+
+internal actual fun Paint.applyShadowMaskFilter(radius: Float) {
+    asFrameworkPaint().maskFilter = BlurMaskFilter(radius, BlurMaskFilter.Blur.NORMAL)
+}
+
+internal actual fun supportFluentElevation(): Boolean {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+}

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/background/Elevation.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/background/Elevation.kt
@@ -1,0 +1,143 @@
+package com.konyaco.fluent.background
+
+import androidx.compose.foundation.border
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.ClipOp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.konyaco.fluent.FluentTheme
+
+@Composable
+fun Modifier.elevation(
+    elevation: Dp,
+    shape: Shape,
+    isDarkTheme: Boolean = FluentTheme.colors.darkMode,
+) = when {
+    elevation.value < 1f -> this
+    elevation.value < 3f -> border(
+        width = 1.dp,
+        brush = if (elevation.value < 2f) {
+            SolidColor(FluentTheme.colors.stroke.card.default)
+        } else {
+            Brush.verticalGradient(
+                0.5f to FluentTheme.colors.stroke.control.default,
+                0.95f to FluentTheme.colors.stroke.control.secondary,
+            )
+        },
+        shape = shape
+    )
+
+    else -> platformElevation(shape = shape, elevation = elevation, isDarkTheme = isDarkTheme)
+}
+
+internal fun Modifier.platformElevation(
+    elevation: Dp,
+    shape: Shape,
+    isDarkTheme: Boolean,
+    borderWidth: Dp = 1.dp,
+): Modifier {
+    if (elevation.value <= 2f) return this
+    val spotColorOpacity: Float
+    val ambientColorOpacity: Float
+    when {
+        isDarkTheme && elevation.value <= 32 -> {
+            spotColorOpacity = 0.26f
+            ambientColorOpacity = 0f
+        }
+
+        isDarkTheme -> {
+            spotColorOpacity = 0.37f
+            ambientColorOpacity = 0.37f
+        }
+
+        elevation.value <= 32 -> {
+            spotColorOpacity = minOf(14f, elevation.value + 6) / 100
+            ambientColorOpacity = 0f
+        }
+
+        else -> {
+            spotColorOpacity = 0.19f
+            ambientColorOpacity = 0.15f
+        }
+    }
+    val spotColor = Color.Black.copy(alpha = spotColorOpacity.coerceIn(0f, 1f))
+    val ambientColor = Color.Black.copy(alpha = ambientColorOpacity.coerceIn(0f, 1f))
+    return if (!supportFluentElevation()) {
+        shadow(
+            elevation = elevation / 2,
+            shape = shape,
+            spotColor = spotColor,
+            ambientColor = ambientColor
+        )
+    } else {
+        drawWithCache {
+            val spotPaint = Paint()
+            val ambientPaint = Paint()
+            val spotBlurRadius = 0.5f * elevation.toPx()
+            val ambientBlurRadius = 0.167f * elevation.toPx()
+
+            spotPaint.color = spotColor
+            ambientPaint.color = ambientColor
+            spotPaint.isAntiAlias = false
+            spotPaint.applyShadowMaskFilter(spotBlurRadius)
+            ambientPaint.isAntiAlias = false
+            ambientPaint.applyShadowMaskFilter(ambientBlurRadius)
+            val borderWidthPx = borderWidth.toPx()
+            val path = Path().apply {
+                addOutline(
+                    shape.createOutline(
+                        size = Size(width = size.width - 2 * borderWidthPx, height = size.height - 2 * borderWidthPx),
+                        layoutDirection = layoutDirection,
+                        density = this@drawWithCache
+                    )
+                )
+            }
+            onDrawWithContent {
+                val offsetY = elevation.toPx() * 0.25f
+                withTransform({
+                    translate(left = borderWidthPx, top = borderWidthPx)
+                    clipPath(path = path, clipOp = ClipOp.Difference)
+                    translate(left = 0f, top = offsetY)
+                }) {
+                    drawContext.canvas.drawPath(path, spotPaint)
+                }
+
+                if (elevation.value > 32f) {
+                    // ambient shadow
+                    withTransform({
+                        translate(left = 0.5f * borderWidthPx, top = 0.5f * borderWidthPx)
+                        clipPath(path = path, clipOp = ClipOp.Difference)
+                    }) {
+                        drawContext.canvas.drawPath(path, ambientPaint)
+                    }
+                }
+                drawContent()
+            }
+        }
+    }
+}
+
+object ElevationDefaults {
+    val layer: Dp = 0.dp
+    val control: Dp = 2.dp
+    val cardRest: Dp = 8.dp
+    val tooltip: Dp = 16.dp
+    val flyout: Dp = 32.dp
+    val dialog: Dp = 128.dp
+}
+
+internal expect fun Paint.applyShadowMaskFilter(radius: Float)
+
+internal expect fun supportFluentElevation(): Boolean

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/background/Layer.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/background/Layer.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.translate
@@ -111,6 +110,7 @@ fun Layer(
     }
 }
 
+@Composable
 private fun Modifier.layer(
     elevation: Dp,
     shape: Shape,
@@ -119,7 +119,7 @@ private fun Modifier.layer(
     color: Color
 ) = then(
     Modifier
-        .shadow(elevation = elevation, shape = shape, clip = false)
+        .elevation(elevation = elevation, shape = shape)
         .then(
             if (border != null) {
                 val backgroundShape =
@@ -146,12 +146,7 @@ private value class BackgroundPaddingShape(private val borderShape: CornerBasedS
 
     override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
         return with(density) {
-            val circular = borderShape == CircleShape
-            val paddingPx = when {
-                circular -> calcCircularPadding(density)
-                else -> calcPadding(density)
-            }.toPx()
-            createInnerOutline(size, density, layoutDirection, paddingPx)
+            createInnerOutline(size, density, layoutDirection, borderShape.calculateBorderPadding(density))
         }
     }
 
@@ -228,5 +223,15 @@ private fun calcCircularPadding(density: Density): Dp {
     return with(density) {
         if (remainder == 0f) 1.dp
         else (1.dp.toPx() - remainder + 1).toDp()
+    }
+}
+
+internal fun Shape.calculateBorderPadding(density: Density): Float {
+    val circular = this == CircleShape
+    return with(density) {
+        when {
+            circular -> calcCircularPadding(density)
+            else -> calcPadding(density)
+        }.toPx()
     }
 }

--- a/fluent/src/desktopMain/kotlin/com/konyaco/fluent/background/Elevation.desktop.kt
+++ b/fluent/src/desktopMain/kotlin/com/konyaco/fluent/background/Elevation.desktop.kt
@@ -1,0 +1,17 @@
+package com.konyaco.fluent.background
+
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.Paint
+import org.jetbrains.skia.FilterBlurMode
+import org.jetbrains.skia.MaskFilter
+
+internal actual fun Paint.applyShadowMaskFilter(radius: Float) {
+    asFrameworkPaint().maskFilter = MaskFilter.makeBlur(
+        mode = FilterBlurMode.NORMAL,
+        sigma = BlurEffect.convertRadiusToSigma(radius)
+    )
+}
+
+internal actual fun supportFluentElevation(): Boolean {
+    return true
+}

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/design/ElevationScreen.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/design/ElevationScreen.kt
@@ -1,0 +1,142 @@
+package com.konyaco.fluent.gallery.screen.design
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.konyaco.fluent.ExperimentalFluentApi
+import com.konyaco.fluent.FluentTheme
+import com.konyaco.fluent.FluentThemeConfiguration
+import com.konyaco.fluent.background.BackgroundSizing
+import com.konyaco.fluent.background.ElevationDefaults
+import com.konyaco.fluent.background.Layer
+import com.konyaco.fluent.component.Slider
+import com.konyaco.fluent.component.Text
+import com.konyaco.fluent.gallery.annotation.Component
+import com.konyaco.fluent.gallery.annotation.Sample
+import com.konyaco.fluent.gallery.component.ComponentPagePath
+import com.konyaco.fluent.gallery.component.GalleryPage
+import com.konyaco.fluent.source.generated.FluentSourceFile
+
+@OptIn(ExperimentalFluentApi::class)
+@Component(index = 0, icon = "Layer")
+@Composable
+fun ElevationScreen() {
+    GalleryPage(
+        title = "Elevation",
+        description = "Creating a visual hierarchy of elements in your UI makes the UI easy to scan and conveys what is important to focus on. " +
+                "Elevation, the act of bringing select elements of your UI forward, is often used to achieve hierarchy.",
+        componentPath = FluentSourceFile.Elevation,
+        galleryPath = ComponentPagePath.ElevationScreen,
+    ) {
+        Section {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Elevation types", style = FluentTheme.typography.bodyStrong)
+                FluentThemeConfiguration {
+                    Layer(
+                        border = null,
+                        color = Color.Transparent,
+                        backgroundSizing = BackgroundSizing.OuterBorderEdge,
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            val items = listOf(
+                                ElevationDefaults::layer.name to ElevationDefaults.layer,
+                                ElevationDefaults::control.name to ElevationDefaults.control,
+                                ElevationDefaults::cardRest.name to ElevationDefaults.cardRest,
+                                ElevationDefaults::tooltip.name to ElevationDefaults.tooltip,
+                                ElevationDefaults::flyout.name to ElevationDefaults.flyout,
+                                ElevationDefaults::dialog.name to ElevationDefaults.dialog
+                            )
+                            items.forEach { (name, elevation) ->
+                                Column(
+                                    modifier = Modifier.weight(1f)
+                                        .wrapContentWidth(Alignment.Start),
+                                    horizontalAlignment = Alignment.CenterHorizontally
+                                ) {
+                                    Text(name.replaceFirstChar { it.uppercase() })
+                                    ElevationBoxSample(
+                                        elevation = elevation,
+                                        modifier = Modifier.padding(vertical = 8.dp)
+                                            .padding(bottom = 56.dp)
+                                    )
+                                }
+                            }
+
+                        }
+                    }
+                }
+            }
+        }
+        val elevation = remember { mutableStateOf(0) }
+        Section(
+            title = "Basic Elevation",
+            sourceCode = sourceCodeOfElevationBoxSample,
+            content = {
+                Box(modifier = Modifier.size(200.dp), contentAlignment = Alignment.Center) {
+                    ElevationBoxSample(elevation.value.dp)
+                }
+            },
+            options = {
+                Slider(
+                    value = elevation.value.toFloat(),
+                    onValueChange = { elevation.value = it.toInt() },
+                    valueRange = 0f..128f,
+                    modifier = Modifier.height(32.dp).width(200.dp)
+                )
+            }
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun ElevationBoxSample(
+    elevation: Dp,
+    modifier: Modifier = Modifier,
+    shape: Shape = CircleShape
+) {
+    Layer(
+        backgroundSizing = BackgroundSizing.InnerBorderEdge,
+        border = BorderStroke(
+            width = 1.dp,
+            color = when {
+                elevation.value > 2f -> FluentTheme.colors.stroke.surface.flyout
+                elevation.value in 0f..1f -> FluentTheme.colors.stroke.card.default
+                else -> Color.Transparent
+            }
+        ),
+        color = FluentTheme.colors.background.solid.quaternary,
+        shape = shape,
+        elevation = elevation,
+        modifier = modifier
+    ) {
+        Text(
+            text = "depth\n${elevation.value.toInt()}",
+            textAlign = TextAlign.Center,
+            color = FluentTheme.colors.text.text.secondary,
+            modifier = Modifier.size(boxSize).wrapContentSize(Alignment.Center)
+        )
+    }
+}
+
+private val boxSize = 80.dp


### PR DESCRIPTION
## Component
`Modifier.elevation()`

## Basic usage
```kotlin
val elevation = ElevationDefaults.flyout
Layer(
    elevation = elevation,
    backgroundSizing = BackgroundSizing.InnerBorderEdge,
    border = BorderStroke(
        width = 1.dp,
        color = when {
            elevation.value > 2f -> FluentTheme.colors.stroke.surface.flyout
            elevation.value in 0f..1f -> FluentTheme.colors.stroke.card.default
            else -> Color.Transparent
        }
    ),
    color = FluentTheme.colors.background.solid.quaternary
)
```

## Screenshot
1.Flyout
![image](https://github.com/Konyaco/compose-fluent-ui/assets/26089739/921bd330-77c4-4a7e-9e5a-708dfdd47803)
2.Dropdown
![image](https://github.com/Konyaco/compose-fluent-ui/assets/26089739/c7ad7f3b-c223-492e-8a80-876f1ec33896)
3.Gallery
![image](https://github.com/Konyaco/compose-fluent-ui/assets/26089739/36f85ff7-a161-491f-bdb5-f0a6332cd778)

