### PR TITLE
[fluent] Update `kotlin` version to 2.0.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.plugin.compose) apply false
     id("com.konyaco.fluent.plugin.build")
 }
 

--- a/fluent-icons-core/build.gradle.kts
+++ b/fluent-icons-core/build.gradle.kts
@@ -4,6 +4,7 @@ import com.konyaco.fluent.plugin.build.applyTargets
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.compose)
+    alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.android.library)
     alias(libs.plugins.ksp)
     id("maven-publish")

--- a/fluent-icons-extended/build.gradle.kts
+++ b/fluent-icons-extended/build.gradle.kts
@@ -3,6 +3,7 @@ import com.konyaco.fluent.plugin.build.applyTargets
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.compose)
     alias(libs.plugins.android.library)
     alias(libs.plugins.ksp)

--- a/fluent/build.gradle.kts
+++ b/fluent/build.gradle.kts
@@ -3,6 +3,7 @@ import com.konyaco.fluent.plugin.build.applyTargets
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.compose)
     alias(libs.plugins.android.library)
     alias(libs.plugins.ksp)

--- a/gallery/build.gradle.kts
+++ b/gallery/build.gradle.kts
@@ -1,9 +1,11 @@
 import com.konyaco.fluent.plugin.build.BuildConfig
 import com.konyaco.fluent.plugin.build.applyTargets
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.compose)
     alias(libs.plugins.android.application)
     alias(libs.plugins.ksp)
@@ -116,7 +118,7 @@ dependencies {
 
 // workaround for KSP only in Common Main.
 // https://github.com/google/ksp/issues/567
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
+tasks.withType<KotlinCompilationTask<*>>().all {
     if (name != "kspCommonMainKotlinMetadata") {
         dependsOn("kspCommonMainKotlinMetadata")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 activityCompose = "1.8.2"
 haze = "0.7.2"
-kotlin = "1.9.23"
-ksp = "1.9.23-1.0.20"
+kotlin = "2.0.20"
+ksp = "2.0.20-1.0.25"
 compose = "1.6.10"
 androidGradlePlugin = "8.3.2"
 androidBuildTools = "31.3.2"
@@ -31,6 +31,7 @@ jna = { module = "net.java.dev.jna:jna-jpms",  version.ref = "jna" }
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-plugin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }

--- a/source-generated/build.gradle.kts
+++ b/source-generated/build.gradle.kts
@@ -3,6 +3,7 @@ import com.konyaco.fluent.plugin.build.applyTargets
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.compose)
     alias(libs.plugins.android.library)
 }


### PR DESCRIPTION
1. Update kotlin to 2.0.20.
2. Update ksp to 1.0.25
3. Replace `androidx.compose` compiler plugin with `kotlin.plugin.compose` compiler plugin.