### PR TITLE
[gallery] chore(deps): Update Haze to 1.0.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activityCompose = "1.9.3"
-haze = "0.9.0-rc03"
+haze = "1.0.2"
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.26"
 compose = "1.7.0"


### PR DESCRIPTION
This commit updates the Haze dependency version to 1.0.2.