### PR TITLE
[fluent] Fix: Prevent TabView from exceeding its bounds

### DIFF
--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TabView.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/TabView.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
@@ -154,6 +155,7 @@ fun TabRow(
                 modifier = Modifier
                     .onGloballyPositioned { rowRect.value = it.boundsInParent() }
                     .weight(1f)
+                    .wrapContentWidth(Alignment.Start)
                     .height(TabViewHeight)
                     .zIndex(1f)
             )

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/navigation/TabViewScreen.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/navigation/TabViewScreen.kt
@@ -151,7 +151,7 @@ internal fun TabViewWindowContent(
 ) {
     Column(modifier = Modifier.windowInsetsPadding(paddingInsets)) {
         val selectedIndex = remember { mutableStateOf(1) }
-        val tabItems = remember { mutableStateListOf(*Array(100) { it + 1 }) }
+        val tabItems = remember { mutableStateListOf(*Array(6) { it + 1 }) }
         val state = rememberLazyListState()
         val endDividerController = rememberTabItemEndDividerController(
             selectedKey = { selectedIndex.value },


### PR DESCRIPTION
This commit fixes an issue where the `TabView` content could exceed its bounds, potentially causing layout issues.

The fix involves wrapping the content with `wrapContentWidth(Alignment.Start)`, ensuring that the content is constrained within the available width and aligned to the start. This prevents overflow and maintains the intended layout.