### PR TITLE
[fluent] Add `SelectorBar` component

### DIFF
--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/SelectorBar.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/SelectorBar.kt
@@ -1,0 +1,154 @@
+package com.konyaco.fluent.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.konyaco.fluent.FluentTheme
+import com.konyaco.fluent.background.Layer
+import com.konyaco.fluent.layout.HorizontalIndicatorContentLayout
+import com.konyaco.fluent.scheme.PentaVisualScheme
+import com.konyaco.fluent.scheme.VisualStateScheme
+import com.konyaco.fluent.scheme.collectVisualState
+
+@Composable
+inline fun SelectorBar(
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically,
+        content = content
+    )
+}
+
+@Composable
+fun SelectorBarItem(
+    selected: Boolean,
+    onSelectedChange: (Boolean) -> Unit,
+    text: (@Composable () -> Unit)?,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+    colors: VisualStateScheme<SelectorBarItemColor> = if (selected) {
+        SelectorBarDefaults.selectedItemColors()
+    } else {
+        SelectorBarDefaults.defaultItemColors()
+    },
+    enabled: Boolean = true,
+    indicator: @Composable (color: Color) -> Unit = { HorizontalIndicator(color = it, visible = selected) },
+    interactionSource: MutableInteractionSource? = null,
+) {
+    val iconOnly = icon != null && text == null
+
+    val targetInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+    val currentColor = colors.schemeFor(targetInteractionSource.collectVisualState(!enabled))
+
+    Layer(
+        color = currentColor.fillColor,
+        contentColor = currentColor.contentColor,
+        border = null,
+        modifier = modifier.widthIn(if (iconOnly) 40.dp else 49.dp)
+            .heightIn(40.dp)
+            .selectable(
+                selected = selected,
+                enabled = enabled,
+                interactionSource = targetInteractionSource,
+                indication = null,
+                onClick = { onSelectedChange(!selected) }
+            )
+    ) {
+        HorizontalIndicatorContentLayout(
+            modifier = Modifier.height(40.dp),
+            text = text,
+            icon = icon,
+            trailing = null,
+            indicator = { indicator(currentColor.indicatorColor) }
+        )
+    }
+}
+
+object SelectorBarDefaults {
+
+    @Composable
+    @Stable
+    fun defaultItemColors(
+        default: SelectorBarItemColor = SelectorBarItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.primary,
+            indicatorColor = FluentTheme.colors.fillAccent.default
+        ),
+        hovered: SelectorBarItemColor = SelectorBarItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.secondary,
+            indicatorColor = FluentTheme.colors.fillAccent.default
+        ),
+        pressed: SelectorBarItemColor = SelectorBarItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.tertiary,
+            indicatorColor = FluentTheme.colors.fillAccent.default
+        ),
+        disabled: SelectorBarItemColor = SelectorBarItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.disabled,
+            indicatorColor = FluentTheme.colors.fillAccent.disabled
+        )
+    ) = SelectorBarItemColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+    
+    @Composable
+    @Stable
+    fun selectedItemColors(
+        default: SelectorBarItemColor = SelectorBarItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.primary,
+            indicatorColor = FluentTheme.colors.fillAccent.default
+        ),
+        hovered: SelectorBarItemColor = SelectorBarItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.secondary,
+            indicatorColor = FluentTheme.colors.fillAccent.default
+        ),
+        pressed: SelectorBarItemColor = SelectorBarItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.tertiary,
+            indicatorColor = FluentTheme.colors.fillAccent.default
+        ),
+        disabled: SelectorBarItemColor = SelectorBarItemColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.disabled,
+            indicatorColor = FluentTheme.colors.fillAccent.disabled
+        )
+    ) = SelectorBarItemColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled
+    )
+}
+
+@Immutable
+data class SelectorBarItemColor(
+    val fillColor: Color,
+    val contentColor: Color,
+    val indicatorColor: Color,
+)
+
+typealias SelectorBarItemColorScheme = PentaVisualScheme<SelectorBarItemColor>

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/navigation/SelectorBarScreen.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/navigation/SelectorBarScreen.kt
@@ -1,0 +1,65 @@
+package com.konyaco.fluent.gallery.screen.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.konyaco.fluent.component.Icon
+import com.konyaco.fluent.component.SelectorBar
+import com.konyaco.fluent.component.SelectorBarItem
+import com.konyaco.fluent.component.Text
+import com.konyaco.fluent.gallery.annotation.Component
+import com.konyaco.fluent.gallery.annotation.Sample
+import com.konyaco.fluent.gallery.component.ComponentPagePath
+import com.konyaco.fluent.gallery.component.GalleryPage
+import com.konyaco.fluent.icons.Icons
+import com.konyaco.fluent.icons.regular.History
+import com.konyaco.fluent.icons.regular.Share
+import com.konyaco.fluent.icons.regular.Star
+import com.konyaco.fluent.source.generated.FluentSourceFile
+
+@Component(description = "Presents information from a small set of different sources. The user can pick one of them.")
+@Composable
+fun SelectorBarScreen() {
+    GalleryPage(
+        title = "SelectorBar",
+        description = "SelectorBar is used to modify the content shown by allowing users to select and switch between a small, finite set of data.",
+        componentPath = FluentSourceFile.SelectorBar,
+        galleryPath = ComponentPagePath.SelectorBarScreen
+    ) {
+        Section(
+            title = "Basic SelectorBar sample",
+            sourceCode = sourceCodeOfBasicSelectorBarSample,
+            content = { BasicSelectorBarSample() }
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun BasicSelectorBarSample() {
+    var selectedIndex by remember { mutableIntStateOf(-1) }
+    SelectorBar {
+        SelectorBarItem(
+            selected = selectedIndex == 0,
+            onSelectedChange = { selectedIndex = 0 },
+            text = { Text("Recent") },
+            icon = { Icon(Icons.Default.History, contentDescription = null) }
+        )
+
+        SelectorBarItem(
+            selected = selectedIndex == 1,
+            onSelectedChange = { selectedIndex = 1 },
+            text = { Text("Shared") },
+            icon = { Icon(Icons.Default.Share, contentDescription = null) }
+        )
+
+        SelectorBarItem(
+            selected = selectedIndex == 2,
+            onSelectedChange = { selectedIndex = 2 },
+            text = { Text("Favorites") },
+            icon = { Icon(Icons.Default.Star, contentDescription = null) }
+        )
+    }
+}


### PR DESCRIPTION
This commit introduces the `SelectorBar` component, a control that lets a user switch between a small number of different sets or views of data. It supports an icon and text, and it's intended to present a limited number of options.

![image](https://github.com/user-attachments/assets/749ab56a-11a9-4092-8889-f8418edf8737)
