### PR TITLE
[fluent] feat: Implement MenuBar component

### DIFF
--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuBar.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuBar.kt
@@ -1,0 +1,429 @@
+package com.konyaco.fluent.component
+
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.konyaco.fluent.FluentTheme
+import com.konyaco.fluent.icons.Icons
+import com.konyaco.fluent.icons.regular.MoreHorizontal
+import com.konyaco.fluent.layout.overflow.OverflowRow
+import com.konyaco.fluent.layout.overflow.OverflowRowScope
+import kotlin.jvm.JvmInline
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@Composable
+fun MenuBar(
+    modifier: Modifier = Modifier,
+    content: @Composable MenuBarScope.() -> Unit
+) {
+    val scope = remember { MenuBarItemScopeImpl() }
+    Row(
+        modifier = modifier.height(MenuBarHeight),
+        horizontalArrangement = Arrangement.spacedBy(MenuBarItemSpacing),
+        verticalAlignment = Alignment.CenterVertically,
+        content = { scope.content() }
+    )
+}
+
+@Composable
+fun MenuBarScope.MenuBarItem(
+    items: @Composable MenuFlyoutContainerScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val item = registerMenuBarItem(interactionSource)
+    Box(modifier = modifier, propagateMinConstraints = true) {
+        val containerScope = rememberNavigationItemsFlyoutScope(
+            expanded = currentItem == item,
+            onExpandedChanged = {
+                if (it) {
+                    currentItem = item
+                } else if (currentItem == item) {
+                    currentItem = null
+                }
+            }
+        )
+        MenuFlyout(
+            visible = containerScope.isFlyoutVisible,
+            onDismissRequest = { containerScope.isFlyoutVisible = false },
+            positionProvider = rememberFlyoutPositionProvider(
+                initialPlacement = FlyoutPlacement.BottomAlignedStart,
+                adaptivePlacement = true,
+                paddingToAnchor = PaddingValues()
+            ),
+            content = { items(containerScope) }
+        )
+
+        MenuBarButton(
+            selected = currentItem == item,
+            onClick = { currentItem = item },
+            interaction = interactionSource,
+            content = { content() }
+        )
+    }
+}
+
+@Composable
+fun OverflowMenuBarItemScope.MenuBarItem(
+    items: @Composable MenuFlyoutContainerScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val item = registerMenuBarItem(interactionSource)
+    Box(modifier = modifier, propagateMinConstraints = true) {
+        val containerScope = rememberNavigationItemsFlyoutScope(
+            expanded = currentItem == item,
+            onExpandedChanged = {
+                if (it) {
+                    currentItem = item
+                } else if (currentItem == item) {
+                    currentItem = null
+                }
+            }
+        )
+        if (!isOverflow) {
+            MenuFlyout(
+                visible = containerScope.isFlyoutVisible,
+                onDismissRequest = { containerScope.isFlyoutVisible = false },
+                positionProvider = rememberFlyoutPositionProvider(
+                    initialPlacement = FlyoutPlacement.BottomAlignedStart,
+                    adaptivePlacement = true,
+                    paddingToAnchor = PaddingValues()
+                ),
+                content = { items(containerScope) }
+            )
+
+            MenuBarButton(
+                selected = currentItem == item,
+                onClick = { currentItem = item },
+                interaction = interactionSource,
+                content = { content() }
+            )
+        } else {
+
+            Box(modifier = modifier, propagateMinConstraints = true) {
+                val containerScope = rememberNavigationItemsFlyoutScope(
+                    expanded = currentItem == item,
+                    onExpandedChanged = {
+                        if (it) {
+                            currentItem = item
+                        } else if (currentItem == item) {
+                            currentItem = null
+                        }
+                    }
+                )
+                val paddingTop = with(LocalDensity.current) { flyoutPopPaddingFixShadowRender.roundToPx() }
+                MenuFlyout(
+                    visible = containerScope.isFlyoutVisible,
+                    onDismissRequest = { containerScope.isFlyoutVisible = false },
+                    positionProvider = rememberSubMenuFlyoutPositionProvider(),
+                    enterPlacementAnimation = {
+                        defaultMenuFlyoutEnterPlacementAnimation(it, paddingTop)
+                    },
+                    content = { items(containerScope) }
+                )
+
+                ListItem(
+                    onClick = { currentItem = item },
+                    trailing = { ListItemDefaults.CascadingIcon() },
+                    text = { content() },
+                    interaction = interactionSource,
+                    colors = if (currentItem == item) {
+                        ListItemDefaults.selectedListItemColors()
+                    } else {
+                        ListItemDefaults.defaultListItemColors()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun OverflowMenuBar(
+    modifier: Modifier = Modifier,
+    content: OverflowMenuBarScope.() -> Unit
+) {
+    val menuBarScope = remember { MenuBarItemScopeImpl() }
+    val overflowItems = remember { mutableListOf<MenuBarItem>() }
+    OverflowRow(
+        modifier = modifier.height(MenuBarHeight),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MenuBarItemSpacing),
+        overflowAction = {
+            var expanded by remember { mutableStateOf(false) }
+            Box {
+                MenuFlyout(
+                    visible = expanded,
+                    onDismissRequest = { expanded = false },
+                    positionProvider = rememberFlyoutPositionProvider(
+                        initialPlacement = FlyoutPlacement.BottomAlignedEnd,
+                        adaptivePlacement = false,
+                        paddingToAnchor = PaddingValues()
+                    ),
+                    content = {
+                        repeat(overflowItemCount) { index ->
+                            overflowItem(index)
+                        }
+                    }
+                )
+                val interactionSource = remember { MutableInteractionSource() }
+                val item = menuBarScope.registerMenuBarItem(interactionSource)
+                DisposableEffect(item, overflowItems) {
+                    overflowItems.add(item)
+                    onDispose {
+                        overflowItems.remove(item)
+                    }
+                }
+                LaunchedEffect(menuBarScope.currentItem, overflowItems) {
+                    if (menuBarScope.currentItem != null) {
+                        expanded = menuBarScope.currentItem in overflowItems
+                    }
+                }
+                MenuBarButton(
+                    selected = expanded,
+                    onClick = { menuBarScope.currentItem = item },
+                    interaction = interactionSource,
+                    content = {
+                        FontIcon(
+                            glyph = '\uE712',
+                            vector = Icons.Default.MoreHorizontal,
+                            contentDescription = null,
+                        )
+                    }
+                )
+            }
+        }
+    ) {
+        OverflowMenuBarScopeImpl(this, overflowItems, menuBarScope).content()
+    }
+}
+
+@Composable
+fun MenuBarButton(
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    interaction: MutableInteractionSource = remember { MutableInteractionSource() },
+    buttonColors: ButtonColorScheme = if (selected) {
+        MenuBarDefaults.selectedItemColors()
+    } else {
+        MenuBarDefaults.defaultItemColors()
+    },
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit,
+) {
+    SubtleButton(
+        interaction = interaction,
+        buttonColors = buttonColors,
+        onClick = onClick,
+        content = { content() },
+        disabled = !enabled,
+        modifier = modifier
+    )
+}
+
+object MenuBarDefaults {
+
+    @Stable
+    @Composable
+    fun selectedItemColors(
+        default: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.subtleFill.tertiary,
+            contentColor = FluentTheme.colors.text.text.primary,
+            borderBrush = SolidColor(Color.Transparent)
+        ),
+        hovered: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.secondary,
+        ),
+        pressed: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.tertiary,
+            contentColor = FluentTheme.colors.text.text.secondary
+        ),
+        disabled: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.disabled,
+            contentColor = FluentTheme.colors.text.text.disabled
+        )
+    ) = ButtonColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled,
+    )
+
+    @Stable
+    @Composable
+    fun defaultItemColors(
+        default: ButtonColor = ButtonColor(
+            fillColor = FluentTheme.colors.subtleFill.transparent,
+            contentColor = FluentTheme.colors.text.text.primary,
+            borderBrush = SolidColor(Color.Transparent)
+        ),
+        hovered: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.secondary,
+        ),
+        pressed: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.tertiary,
+            contentColor = FluentTheme.colors.text.text.secondary
+        ),
+        disabled: ButtonColor = default.copy(
+            fillColor = FluentTheme.colors.subtleFill.disabled,
+            contentColor = FluentTheme.colors.text.text.disabled
+        )
+    ) = ButtonColorScheme(
+        default = default,
+        hovered = hovered,
+        pressed = pressed,
+        disabled = disabled,
+    )
+}
+
+interface MenuBarScope : MenuBarItemScope
+
+interface OverflowMenuBarScope {
+    fun item(
+        key: Any? = null,
+        contentType: Any? = null,
+        content: @Composable OverflowMenuBarItemScope.() -> Unit
+    )
+
+    fun items(
+        count: Int,
+        key: ((index: Int) -> Any)? = null,
+        contentType: (index: Int) -> Any? = { null },
+        itemContent: @Composable OverflowMenuBarItemScope.(index: Int) -> Unit
+    )
+}
+
+@Immutable
+private class OverflowMenuBarScopeImpl(
+    private val rowScope: OverflowRowScope,
+    overflowItems: MutableList<MenuBarItem>,
+    menuBarScope: MenuBarItemScope = MenuBarItemScopeImpl(),
+) : OverflowMenuBarScope {
+    private val normalItemScope = NormalItemScope(menuBarScope)
+    private val overflowItemScope = OverflowItemScope(overflowItems, menuBarScope)
+
+    override fun items(
+        count: Int,
+        key: ((Int) -> Any)?,
+        contentType: (Int) -> Any?,
+        itemContent: @Composable (OverflowMenuBarItemScope.(Int) -> Unit)
+    ) {
+        rowScope.items(count, key, contentType) {
+            if (isOverflow) {
+                overflowItemScope.itemContent(it)
+            } else {
+                normalItemScope.itemContent(it)
+            }
+        }
+    }
+
+    override fun item(
+        key: Any?,
+        contentType: Any?,
+        content: @Composable OverflowMenuBarItemScope.() -> Unit
+    ) {
+        rowScope.item(key, contentType) {
+            if (isOverflow) {
+                overflowItemScope.content()
+            } else {
+                normalItemScope.content()
+            }
+        }
+    }
+
+    class NormalItemScope(
+        private val itemScopeDelegate: MenuBarItemScope
+    ) : OverflowMenuBarItemScope, MenuBarItemScope by itemScopeDelegate {
+        override val isOverflow: Boolean
+            get() = false
+    }
+
+    class OverflowItemScope(
+        private val items: MutableList<MenuBarItem>,
+        private val itemScopeDelegate: MenuBarItemScope
+    ) : OverflowMenuBarItemScope, MenuBarItemScope by itemScopeDelegate {
+        override val isOverflow: Boolean
+            get() = true
+
+        @Composable
+        override fun registerMenuBarItem(interactionSource: InteractionSource): MenuBarItem {
+            val item = itemScopeDelegate.registerMenuBarItem(interactionSource)
+            DisposableEffect(items, item) {
+                items.add(item)
+                onDispose {
+                    items.remove(item)
+                }
+            }
+            return item
+        }
+    }
+}
+
+interface OverflowMenuBarItemScope : MenuBarItemScope {
+    val isOverflow: Boolean
+}
+
+interface MenuBarItemScope {
+
+    var currentItem: MenuBarItem?
+
+    @Composable
+    fun registerMenuBarItem(
+        interactionSource: InteractionSource,
+    ): MenuBarItem
+}
+
+@JvmInline
+@OptIn(ExperimentalUuidApi::class)
+value class MenuBarItem internal constructor(private val uuid: Uuid)
+
+@OptIn(ExperimentalUuidApi::class)
+private class MenuBarItemScopeImpl() : MenuBarScope {
+
+    override var currentItem: MenuBarItem? by mutableStateOf(null)
+
+    @Composable
+    override fun registerMenuBarItem(
+        interactionSource: InteractionSource
+    ): MenuBarItem {
+        val isHovered by interactionSource.collectIsHoveredAsState()
+        val menuBarItem = remember {
+            MenuBarItem(Uuid.random())
+        }
+        LaunchedEffect(isHovered, menuBarItem) {
+            if (currentItem != null && currentItem != menuBarItem && isHovered) {
+                currentItem = menuBarItem
+            }
+        }
+        return menuBarItem
+    }
+}
+
+private val MenuBarItemSpacing = 8.dp
+private val MenuBarHeight = 48.dp

--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuFlyout.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/MenuFlyout.kt
@@ -304,7 +304,7 @@ private class MenuFlyoutContainerScopeImpl(
 ) : MenuFlyoutContainerScope, FlyoutContainerScope by flyoutScope,
     MenuFlyoutScope by menuFlyoutScope
 
-private fun defaultMenuFlyoutEnterPlacementAnimation(
+internal fun defaultMenuFlyoutEnterPlacementAnimation(
     placement: FlyoutPlacement,
     paddingTop: Int
 ): EnterTransition {
@@ -339,7 +339,7 @@ private fun defaultMenuFlyoutEnterPlacementAnimation(
 }
 
 @Composable
-private fun rememberSubMenuFlyoutPositionProvider(
+internal fun rememberSubMenuFlyoutPositionProvider(
     initialPlacement: FlyoutPlacement = FlyoutPlacement.Auto,
     paddingToAnchor: PaddingValues = PaddingValues(vertical = flyoutDefaultPadding)
 ): SubMenuFlyoutPositionProvider {
@@ -350,7 +350,7 @@ private fun rememberSubMenuFlyoutPositionProvider(
 }
 
 @Stable
-private class SubMenuFlyoutPositionProvider(
+internal class SubMenuFlyoutPositionProvider(
     density: Density,
     initialPlacement: FlyoutPlacement,
     paddingToAnchor: PaddingValues,

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/menus/MenuBarScreen.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/menus/MenuBarScreen.kt
@@ -1,0 +1,258 @@
+package com.konyaco.fluent.gallery.screen.menus
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.konyaco.fluent.component.ListItemDefaults
+import com.konyaco.fluent.component.ListItemSelectionType
+import com.konyaco.fluent.component.MenuBar
+import com.konyaco.fluent.component.MenuBarItem
+import com.konyaco.fluent.component.MenuFlyoutItem
+import com.konyaco.fluent.component.MenuFlyoutSeparator
+import com.konyaco.fluent.component.OverflowMenuBar
+import com.konyaco.fluent.component.Text
+import com.konyaco.fluent.gallery.annotation.Component
+import com.konyaco.fluent.gallery.annotation.Sample
+import com.konyaco.fluent.gallery.component.ComponentPagePath
+import com.konyaco.fluent.gallery.component.GalleryPage
+import com.konyaco.fluent.source.generated.FluentSourceFile
+
+@Component(description = "A classic menu, allowing the display of MenuItems containing MenuFlyoutItems")
+@Composable
+fun MenuBarScreen() {
+    GalleryPage(
+        title = "MenuBar",
+        description = "The MenuBar simplifies the creation of basic applications by providing a set of menus at the top of the app or window.",
+        componentPath = FluentSourceFile.MenuBar,
+        galleryPath = ComponentPagePath.MenuBarScreen,
+    ) {
+        Section(
+            title = "A simple MenuBar",
+            sourceCode = sourceCodeOfBasicMenuBarSample,
+            content = { BasicMenuBarSample() }
+        )
+
+        //TODO MenuBar with keyboard accelerator sample
+
+        Section(
+            title = "A MenuBar with SubMenus, Separators and RadioItems",
+            sourceCode = sourceCodeOfMenuBarWithSubMenuSample,
+            content = { MenuBarWithSubMenuSample() }
+        )
+
+        Section(
+            title = "An Overflow MenuBar",
+            sourceCode = sourceCodeOfOverflowMenuBarSample,
+            content = { OverflowMenuBarSample() }
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun BasicMenuBarSample() {
+    MenuBar {
+        MenuBarItem(
+            content = { Text("File") },
+            items = {
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("New") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Open") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Save") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Exit") }
+                )
+            },
+        )
+
+        MenuBarItem(
+            content = { Text("Edit") },
+            items = {
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Undo") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Cut") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Copy") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Paste") }
+                )
+            },
+        )
+
+        MenuBarItem(
+            content = { Text("Help") },
+            items = {
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("About") }
+                )
+            }
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun MenuBarWithSubMenuSample() {
+    MenuBar {
+        MenuBarItem(
+            content = { Text("File") },
+            items = {
+                MenuFlyoutItem(
+                    items = {
+                        MenuFlyoutItem(
+                            onClick = { isFlyoutVisible = false },
+                            text = { Text("Plain Text Document") }
+                        )
+                        MenuFlyoutItem(
+                            onClick = { isFlyoutVisible = false },
+                            text = { Text("Rich Text Document") }
+                        )
+                        MenuFlyoutItem(
+                            onClick = { isFlyoutVisible = false },
+                            text = { Text("Other Formats") }
+                        )
+                    },
+                    text = { Text("New") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Open") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Save") }
+                )
+                MenuFlyoutSeparator()
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Exit") }
+                )
+            },
+        )
+
+        MenuBarItem(
+            content = { Text("Edit") },
+            items = {
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Undo") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Cut") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Copy") }
+                )
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Paste") }
+                )
+            },
+        )
+        var isLandscape by remember { mutableStateOf(false) }
+
+        var iconIndex by remember { mutableStateOf(1) }
+        MenuBarItem(
+            content = { Text("View") },
+            items = {
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("Output") },
+                    icon = {}
+                )
+                MenuFlyoutSeparator()
+
+                MenuFlyoutItem(
+                    text = { Text("Landscape") },
+                    onSelectedChanged = {
+                        isLandscape = true
+                        isFlyoutVisible = false
+                    },
+                    selected = isLandscape,
+                    selectionType = ListItemSelectionType.Radio,
+                    colors = ListItemDefaults.defaultListItemColors()
+                )
+                MenuFlyoutItem(
+                    text = { Text("Portrait") },
+                    onSelectedChanged = {
+                        isLandscape = false
+                        isFlyoutVisible = false
+                    },
+                    selected = !isLandscape,
+                    selectionType = ListItemSelectionType.Radio,
+                    colors = ListItemDefaults.defaultListItemColors()
+                )
+                MenuFlyoutSeparator()
+                repeat(3) { index ->
+                    MenuFlyoutItem(
+                        text = {
+                            Text(
+                                text = when(index) {
+                                    0 -> "Small icons"
+                                    1 -> "Medium icons"
+                                    else -> "Large icons"
+                                }
+                            )
+                        },
+                        selected = index == iconIndex,
+                        onSelectedChanged = { iconIndex = index },
+                        selectionType = ListItemSelectionType.Radio,
+                        colors = ListItemDefaults.defaultListItemColors()
+                    )
+                }
+            }
+        )
+
+        MenuBarItem(
+            content = { Text("Help") },
+            items = {
+                MenuFlyoutItem(
+                    onClick = { isFlyoutVisible = false },
+                    text = { Text("About") }
+                )
+            },
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun OverflowMenuBarSample() {
+    OverflowMenuBar {
+        items(16) {
+            MenuBarItem(
+                items = {
+                    MenuFlyoutItem(
+                        onClick = { isFlyoutVisible = false },
+                        text = { Text("Menu Item 1") }
+                    )
+                },
+                content = {
+                    Text("Menu ${it + 1}")
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the `MenuBar` component, a horizontal menu bar typically used at the top of a window or application to provide access to various commands and options.

It supports `MenuBarItem`s that can open `MenuFlyout`s. Also adds `OverflowMenuBar` component that will automatically handle overflow items by moving them to a separate popup.

The `MenuBar` and `OverflowMenuBar` manage their menu items and popups state, and provides default color schemes for menu items.
![image](https://github.com/user-attachments/assets/886bb148-6dff-4e03-ac8d-73f3347c8e79)
