### PR TITLE
Seperate slider to `Slider` and `BasicSlider`

### DIFF
--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/ColorPicker.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/ColorPicker.kt
@@ -114,7 +114,7 @@ fun ColorPicker(
             ) {}
         }
         val (hug, saturation, _) = spectrumColor.value.hsv()
-        Slider(
+        BasicSlider(
             modifier = Modifier.padding(top = 21.dp).width(312.dp).height(32.dp),
             value = value,
             onValueChange = {
@@ -151,7 +151,7 @@ fun ColorPicker(
             }
         )
         if (alphaEnabled) {
-            Slider(
+            BasicSlider(
                 modifier = Modifier.width(312.dp),
                 value = alpha,
                 onValueChange = {

--- a/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/basicinput/SliderScreen.kt
+++ b/gallery/src/commonMain/kotlin/com/konyaco/fluent/gallery/screen/basicinput/SliderScreen.kt
@@ -1,20 +1,24 @@
 package com.konyaco.fluent.gallery.screen.basicinput
 
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.konyaco.fluent.component.Slider
-import com.konyaco.fluent.component.SliderState
-import com.konyaco.fluent.component.Text
+import com.konyaco.fluent.component.*
 import com.konyaco.fluent.gallery.annotation.Component
 import com.konyaco.fluent.gallery.annotation.Sample
 import com.konyaco.fluent.gallery.component.ComponentPagePath
 import com.konyaco.fluent.gallery.component.GalleryPage
 import com.konyaco.fluent.gallery.component.TodoComponent
 import com.konyaco.fluent.source.generated.FluentSourceFile
+import kotlin.math.roundToInt
 
 @Component(
     index = 12,
@@ -38,11 +42,25 @@ fun SliderScreen() {
             }
         )
 
+        Section(
+            title = "A Slider with tick marks.",
+            sourceCode = sourceCodeOfSliderTickMarkSample,
+            content = { SliderTickMarkSample() }
+        )
+
         val (confirmValue, setConfirmValue) = remember { mutableStateOf(0f) }
-        val stepsSliderState = remember { SliderState(0f, 4, setConfirmValue, 0f..100f) }
+        val stepsSliderState = remember {
+            SliderState(
+                value = 0f,
+                steps = 4,
+                snap = true,
+                onValueChangeFinished = setConfirmValue,
+                valueRange = 0f..100f
+            )
+        }
 
         Section(
-            title = "A Slider with range, steps and tick marks.",
+            title = "A Slider with custom tooltip content and snaps to tickmark.",
             sourceCode = sourceCodeOfSliderStepsSample,
             content = { SliderStepsSample(stepsSliderState) },
             output = {
@@ -50,9 +68,13 @@ fun SliderScreen() {
                 Text("confirmValue: $confirmValue")
             }
         )
-        /*Section("A Slider with tick marks.", "") {
-            TodoComponent()
-        }*/
+
+        Section(
+            title = "Customize slider by using BasicSlider.",
+            sourceCode = sourceCodeOfBasicSliderSample,
+            content = { BasicSliderSample(remember { SliderState(valueRange = 0f..100f) }) },
+        )
+
         Section("A vertical slider with range and tick marks specified.", "") {
             TodoComponent()
         }
@@ -71,9 +93,55 @@ private fun SliderSample(value: Float, onValueChanged: (Float) -> Unit) {
 
 @Sample
 @Composable
+private fun SliderTickMarkSample() {
+    val (value, setValue) = remember { mutableStateOf(0f) }
+    Slider(
+        modifier = Modifier.width(200.dp),
+        valueRange = 0f..100f,
+        value = value,
+        steps = 5,
+        showTickMark = true,
+        snap = false,
+        onValueChange = setValue,
+    )
+}
+
+@Sample
+@Composable
 private fun SliderStepsSample(state: SliderState) {
     Slider(
         modifier = Modifier.width(200.dp),
-        state = state
+        state = state,
+        tooltipContent = {
+            Text(it.nearestValue().roundToInt().toString())
+        },
+    )
+}
+
+@Sample
+@Composable
+private fun BasicSliderSample(state: SliderState) {
+    BasicSlider(
+        modifier = Modifier.width(200.dp),
+        state = state,
+        rail = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .requiredHeight(12.dp)
+                    .clip(CircleShape)
+                    .background(
+                        Brush.horizontalGradient(
+                            0f to Color.White.copy(0f),
+                            1f to Color.Red.copy(1f)
+                        )
+                    )
+            )
+        },
+        track = {
+        },
+        thumb = {
+            SliderDefaults.Thumb(state)
+        }
     )
 }


### PR DESCRIPTION
1. Simplified the Slider API for most common usag. Use BasicSlider t customize slider.
2. Snap behavior and tickmark can be controlled seperately now.