### PR TITLE
feat: Add window frame context menu and accent color support

### DIFF
--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/SkiaLayerWindowProcedure.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/SkiaLayerWindowProcedure.kt
@@ -26,7 +26,7 @@ class SkiaLayerWindowProcedure(
 ): WindowProcedure {
 
     private val windowHandle = HWND(Pointer(skiaLayer.windowHandle))
-    private val contentHandle = HWND(skiaLayer.canvas.let(Native::getComponentPointer))
+    internal val contentHandle = HWND(skiaLayer.canvas.let(Native::getComponentPointer))
     private val defaultWindowProcedure = User32Extend.instance?.setWindowLong(contentHandle, WinUser.GWL_WNDPROC, this) ?: BaseTSD.LONG_PTR(-1)
 
     private var hitResult = 1

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/User32Extend.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/User32Extend.kt
@@ -1,5 +1,6 @@
 package com.konyaco.fluent.gallery.jna.windows
 
+import com.konyaco.fluent.gallery.jna.windows.structure.MENUITEMINFO
 import com.sun.jna.Native
 import com.sun.jna.Platform
 import com.sun.jna.platform.win32.User32
@@ -9,7 +10,9 @@ import com.sun.jna.platform.win32.WinDef.LPARAM
 import com.sun.jna.platform.win32.WinDef.LRESULT
 import com.sun.jna.platform.win32.WinUser.WindowProc
 import com.sun.jna.platform.win32.BaseTSD.LONG_PTR
+import com.sun.jna.platform.win32.WinDef.HMENU
 import com.sun.jna.platform.win32.WinDef.POINT
+import com.sun.jna.platform.win32.WinDef.RECT
 import com.sun.jna.platform.win32.WinDef.UINT
 import com.sun.jna.platform.win32.WinUser
 import com.sun.jna.win32.W32APIOptions
@@ -34,6 +37,14 @@ internal interface User32Extend : User32 {
     fun GetDpiForWindow(hWnd: HWND): UINT
 
     fun ScreenToClient(hWnd: HWND, lpPoint: POINT): Boolean
+
+    fun GetSystemMenu(hWnd: HWND, bRevert: Boolean): HMENU?
+
+    fun SetMenuItemInfo(hMenu: HMENU, uItem: Int, fByPosition: Boolean, lpmii: MENUITEMINFO): Boolean
+
+    fun TrackPopupMenu(hMenu: HMENU, uFlags: Int, x: Int, y: Int, nReserved: Int, hWnd: HWND, prcRect: RECT?): Int
+
+    fun SetMenuDefaultItem(hMenu: HMENU, uItem: Int, fByPos: Boolean): Boolean
 
 
     companion object {

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/MenuItemInfo.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/MenuItemInfo.kt
@@ -1,0 +1,53 @@
+package com.konyaco.fluent.gallery.jna.windows.structure
+
+import com.sun.jna.Structure
+import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR
+import com.sun.jna.platform.win32.WinDef.HBITMAP
+import com.sun.jna.platform.win32.WinDef.HMENU
+
+// Contains information about a menu item.
+@Suppress("SpellCheckingInspection", "unused")
+class MENUITEMINFO : Structure() {
+    @JvmField
+    var cbSize: Int = 0
+
+    @JvmField
+    var fMask: Int = 0
+
+    @JvmField
+    var fType: Int = 0
+
+    @JvmField
+    var fState: Int = 0
+
+    @JvmField
+    var wID: Int = 0
+
+    @JvmField
+    var hSubMenu: HMENU? = null
+
+    @JvmField
+    var hbmpChecked: HBITMAP? = null
+
+    @JvmField
+    var hbmpUnchecked: HBITMAP? = null
+
+    @JvmField
+    var dwItemData: ULONG_PTR = ULONG_PTR(0)
+
+    @JvmField
+    var dwTypeData: String? = null
+
+    @JvmField
+    var cch: Int = 0
+
+    @JvmField
+    var hbmpItem: HBITMAP? = null
+
+    override fun getFieldOrder(): List<String> {
+        return listOf(
+            "cbSize", "fMask", "fType", "fState", "wID", "hSubMenu", "hbmpChecked", "hbmpUnchecked",
+            "dwItemData", "dwTypeData", "cch", "hbmpItem",
+        )
+    }
+}

--- a/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/WinUserConst.kt
+++ b/gallery/src/desktopMain/kotlin/com/konyaco/fluent/gallery/jna/windows/structure/WinUserConst.kt
@@ -18,6 +18,8 @@ object WinUserConst {
     val WM_NCLBUTTONDOWN = 0x00A1
     // non client area left mouse up message
     val WM_NCLBUTTONUP = 0x00A2
+    // non client area right mouse up message
+    val WM_NCRBUTTONUP: Int = 0x00A5
 
     /**
      * [WM_NCHITTEST] Mouse Position Codes
@@ -41,4 +43,31 @@ object WinUserConst {
     internal val HTBOTTOM = 15
     internal val HTBOTTOMLEFT = 16
     internal val HTBOTTOMRIGHT = 17
+
+    // setting changed message
+    const val WM_SETTINGCHANGE: Int = 0x001A
+
+    // window active event
+    const val WM_ACTIVATE: Int = 0x0006
+
+    // window is deactivated
+    const val WA_INACTIVE: Int = 0x00000000
+
+    const val SC_RESTORE: Int = 0x0000f120
+    const val SC_MOVE: Int = 0xF010
+    const val SC_SIZE: Int = 0xF000
+    const val SC_CLOSE: Int = 0xF060
+
+    const val WINT_MAX: Int = 0xFFFF
+
+    const val MIIM_STATE: Int = 0x00000001 // The `fState` member is valid.
+
+    const val MFT_STRING: Int = 0x00000000 // The item is a text string.b
+
+    const val TPM_RETURNCMD: Int =
+        0x0100 // Returns the menu item identifier of the user's selection instead of sending a message.
+
+    const val MFS_ENABLED: Int = 0x00000000 // The item is enabled.
+
+    const val MFS_DISABLED: Int = 0x00000003 // The item is disabled.
 }


### PR DESCRIPTION
feat: Add window frame context menu and accent color support

This commit introduces several enhancements to the window frame:

-   **Context Menu:** Added
``````
 a right-click context menu to the window frame, providing options to restore, move, size, minimize, maximize, and close the window.
-   **Accent Color Support:** Implemented support for the system's accent color in the window frame. The window frame now dynamically adapts to changes in the system'
``````
s color scheme.
-   **Caption Button Customization**: change caption buttons color to system accent color when enabled.
-   **Window Focus Indication:** Added visual feedback to indicate whether the window is in focus or not.
-   **Menu Item Management**: Implemented dynamic enabling and disabling of menu items based on the window's state (e.g., maximized, minimized).
- **Refactor:** Improve window frame component and add related functions to `User32Extend`.
- **Fix:** Fix `WM_NCMOUSEMOVE` message is not sended to the skiaLayer.
```