### PR TITLE
Making the colorpicker TextFields single lined

### DIFF
--- a/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/ColorPicker.kt
+++ b/fluent/src/commonMain/kotlin/com/konyaco/fluent/component/ColorPicker.kt
@@ -381,7 +381,8 @@ private fun ColorTextField(
                 }
             },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.width(120.dp).fillMaxWidth()
+            modifier = Modifier.width(120.dp).fillMaxWidth(),
+            maxLines = 1
         )
         Text(label, color = FluentTheme.colors.text.text.secondary)
     }
@@ -442,7 +443,8 @@ fun HexColorTextField(
             }
             isTextFieldInput.value = false
         },
-        modifier = modifier
+        modifier = modifier,
+        maxLines = 1
     )
 }
 


### PR DESCRIPTION
Adding `maxLines = 1` to `HexColorTextField` and `ColorTextField`