### PR TITLE
Fix inability to close, minimize or move the Gallery on Windows 11

### DIFF
--- a/gallery/src/desktopMain/kotlin/io/github/composefluent/gallery/jna/windows/SkiaLayerWindowProcedure.kt
+++ b/gallery/src/desktopMain/kotlin/io/github/composefluent/gallery/jna/windows/SkiaLayerWindowProcedure.kt
@@ -1,7 +1,9 @@
 package io.github.composefluent.gallery.jna.windows
 
 import io.github.composefluent.gallery.jna.windows.structure.WinUserConst.HTCLIENT
+import io.github.composefluent.gallery.jna.windows.structure.WinUserConst.HTCLOSE
 import io.github.composefluent.gallery.jna.windows.structure.WinUserConst.HTMAXBUTTON
+import io.github.composefluent.gallery.jna.windows.structure.WinUserConst.HTMINBUTTON
 import io.github.composefluent.gallery.jna.windows.structure.WinUserConst.HTTRANSPANRENT
 import io.github.composefluent.gallery.jna.windows.structure.WinUserConst.WM_LBUTTONDOWN
 import io.github.composefluent.gallery.jna.windows.structure.WinUserConst.WM_LBUTTONUP
@@ -48,7 +50,7 @@ class SkiaLayerWindowProcedure(
                 hitResult = hitTest(point.x.toFloat(), point.y.toFloat())
                 point.clear()
                 when(hitResult) {
-                    HTCLIENT, HTMAXBUTTON -> LRESULT(hitResult.toLong())
+                    HTCLIENT, HTMAXBUTTON, HTMINBUTTON, HTCLOSE -> LRESULT(hitResult.toLong())
                     else -> LRESULT(HTTRANSPANRENT.toLong())
                 }
             }

--- a/gallery/src/desktopMain/kotlin/io/github/composefluent/gallery/jna/windows/structure/WinUserConst.kt
+++ b/gallery/src/desktopMain/kotlin/io/github/composefluent/gallery/jna/windows/structure/WinUserConst.kt
@@ -32,8 +32,12 @@ object WinUserConst {
     internal val HTCLIENT = 1
     // title bar
     internal val HTCAPTION = 2
+    // min button
+    internal val HTMINBUTTON = 8
     // max button
     internal val HTMAXBUTTON = 9
+    // close button
+    internal val HTCLOSE = 20
     // window edges
     internal val HTLEFT = 10
     internal val HTRIGHT = 11


### PR DESCRIPTION
# Before : 

https://github.com/user-attachments/assets/cea68e16-1275-43ee-b092-a68c5f73ca79

When running Compose Fluent Gallery on Windows 11, the following exception was thrown every second:

> juin 08, 2025 7:43:12 PM com.sun.jna.Native$1 uncaughtException
AVERTISSEMENT: JNA: Callback io.github.composefluent.gallery.jna.windows.SkiaLayerWindowProcedure@4f719418 threw the following exception
java.lang.IllegalArgumentException: argument type mismatch
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:107)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.github.composefluent.gallery.window.ReflectLayoutHitTestOwner.layoutNodeHitTest(LayoutHitTestOwner.kt:80)
	at io.github.composefluent.gallery.window.CanvasLayersLayoutHitTestOwner.hitTest(LayoutHitTestOwner.kt:162)
	at io.github.composefluent.gallery.window.WindowsWindowFrameKt.WindowsWindowFrame_tJlDC5Y$lambda$9$lambda$7(WindowsWindowFrame.kt:122)
	at io.github.composefluent.gallery.jna.windows.ComposeWindowProcedure.skiaLayerProcedure$lambda$1$lambda$0(ComposeWindowProcedure.kt:125)
	at io.github.composefluent.gallery.jna.windows.SkiaLayerWindowProcedure.callback(SkiaLayerWindowProcedure.kt:48)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.sun.jna.CallbackReference$DefaultCallbackProxy.invokeCallback(CallbackReference.java:585)
	at com.sun.jna.CallbackReference$DefaultCallbackProxy.callback(CallbackReference.java:613)
	at java.desktop/sun.awt.windows.WToolkit.eventLoop(Native Method)
	at java.desktop/sun.awt.windows.WToolkit.run(WToolkit.java:360)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	
Impact: The window could not be closed, minimized, or even moved.

# After :

The window now behaves normally: no more JNA exceptions and the title‑bar buttons respond correctly.

https://github.com/user-attachments/assets/86aa5386-fb24-4a9d-9186-89201f2ff631

