### PR TITLE
[Fix](Expander) Trailing being truncated in small size

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/Expander.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/Expander.kt
@@ -350,13 +350,12 @@ internal fun ExpanderItemContent(
         } else {
             Spacer(modifier = Modifier.width(16.dp))
         }
-        Column(modifier = Modifier.padding(vertical = 13.dp)) {
+        Column(modifier = Modifier.padding(vertical = 13.dp).weight(1f)) {
             heading()
             ProvideTextStyle(FluentTheme.typography.caption.copy(captionTextColor)) {
                 caption()
             }
         }
-        Spacer(modifier = Modifier.weight(1f).height(1.dp))
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(end = 8.dp)


### PR DESCRIPTION
In some case where screen is too small to display heading/caption within one line, the trailing content will be truncated.
| Before  | After |
| -------- | ------- |
| ![](https://github.com/user-attachments/assets/7f0d1afc-0d16-4c4d-b7b9-995113f75770)  |  ![](https://github.com/user-attachments/assets/c0dae087-1676-4454-8477-354db24372ae)   |
