### PR TITLE
Add v to README dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Thank you for using our library. We look forward to receiving your feedback and 
 ### Add Dependency
 
 ```kts
-implementation("io.github.compose-fluent:fluent:0.1.0")
-implementation("io.github.compose-fluent:fluent-icons-extended:0.1.0") // If you want to use full fluent icons.
+implementation("io.github.compose-fluent:fluent:v0.1.0")
+implementation("io.github.compose-fluent:fluent-icons-extended:v0.1.0") // If you want to use full fluent icons.
 ```
 
 #### Snapshot Versions


### PR DESCRIPTION
The stable release's version code begins with a `v`, so this is required for Gradle to resolve it.

https://central.sonatype.com/artifact/io.github.compose-fluent/fluent