### PR TITLE
Fix crash when clearing ColorTextField in ColorPicker

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/ColorPicker.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/ColorPicker.kt
@@ -372,7 +372,7 @@ private fun ColorTextField(
     suffix: String = "",
     range: IntRange = 0..255,
     parse: (Int) -> String = { it.toString() },
-    parseBack: (String) -> Int? = { it.toInt() }
+    parseBack: (String) -> Int? = { it.toIntOrNull() }
 ) {
     //TODO TextField clean button
     var colorTextValue by remember {


### PR DESCRIPTION
Replaces the use of toInt() with toIntOrNull() in ColorTextField's parseBack lambda to prevent exceptions when parsing invalid integer input.

The clear action now empties the text box, consistent with WinUI3 Gallery behavior.