### PR TITLE
fix(fluent): fix Blue and Green label mismatch in ColorPicker

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/ColorPicker.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/ColorPicker.kt
@@ -304,7 +304,7 @@ fun ColorPicker(
                         onSelectedColorChanged(color.copy(green = (it.toFloat() / 255f)))
                         spectrumColor.value = color
                     },
-                    label = "Blue"
+                    label = "Green"
                 )
                 ColorTextField(
                     value = (color.blue * 255).toInt(),
@@ -312,7 +312,7 @@ fun ColorPicker(
                         onSelectedColorChanged(color.copy(blue = (it.toFloat() / 255f)))
                         spectrumColor.value = color
                     },
-                    label = "Green"
+                    label = "Blue"
                 )
             } else {
                 ColorTextField(


### PR DESCRIPTION
Previously, the Green channel text field was labeled "Blue" and vice versa. This change corrects the labels to match their respective color values.