### PR TITLE
fix(Slider): ensure thumb position updates when value changes externally

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/Slider.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/Slider.kt
@@ -373,6 +373,11 @@ class SliderState(
                     valueRange.endInclusive
                 )*/
             valueState = coercedValue
+
+            // When the value is updated externally (not by user dragging), synchronize
+            if (!isDragging) {
+                rawFraction = valueToFraction(coercedValue, valueRange)
+            }
         }
         get() = valueState
 


### PR DESCRIPTION
Slider thumb position (rawFraction) was only updated during user drag interactions. If the `value` was modified programmatically (e.g., via state hoisting or a reset button), the visual thumb position would remain stale and desynchronized from the actual value.

This commit adds a check in the `value` setter to explicitly recalculate and update `rawFraction` when `isDragging` is false, ensuring the UI correctly reflects external state changes.