### PR TITLE
add FluentDialog modifier

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/Dialog.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/Dialog.kt
@@ -93,6 +93,7 @@ fun FluentDialog(
     visible: Boolean,
     size: DialogSize = DialogSize.Standard,
     properties: PopupProperties = PopupProperties(focusable = true),
+    modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
     val visibleState = remember { MutableTransitionState(false) }
@@ -116,7 +117,7 @@ fun FluentDialog(
             durationMillis = FluentDuration.ShortDuration
         )
         Box(
-            Modifier.fillMaxSize()
+            modifier.fillMaxSize()
                 .background(scrim)
                 .pointerInput(Unit) {},
             Alignment.Center


### PR DESCRIPTION
增加对外暴露FluentDialog中Box的modifier属性

原由：需要点击对话框外的一个事件，目前可以这样写：

```kotlin
FluentDialog(
    visible = true,
    size = DialogSize.Min,

    // 用来处理点击对话框外区域，来实现弹窗的关闭
    modifier = Modifier.onClick(enabled = true, onClick = viewModel.onDismissRequest)
) {
    Column(
        modifier = Modifier.padding(all = 24.dp).fillMaxWidth(),
        horizontalAlignment = Alignment.CenterHorizontally,
        verticalArrangement = Arrangement.Center
    ) {
        ProgressRing()
        Spacer(modifier = Modifier.height(height = 16.dp))
        Text(text = viewModel.screenMessageText.value)
    }
}
```