### PR TITLE
Add tri-state checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See [`gallery`](gallery) module for more details.
 - [x] Radio Button
 - [x] Toggle Switch
 - [x] Check Box
-  - [ ] TriState Check Box
+  - [x] TriState Check Box
 - [x] Combo Box (Simple)
 - [x] Progress Bar
 - [x] Progress Ring

--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/CheckBox.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/CheckBox.kt
@@ -1,11 +1,13 @@
 package io.github.composefluent.component
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -15,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.triStateToggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
@@ -24,6 +27,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.dp
 import io.github.composefluent.FluentTheme
 import io.github.composefluent.animation.FluentDuration
@@ -57,18 +65,69 @@ fun CheckBox(
     },
     onCheckStateChange: (checked: Boolean) -> Unit
 ) {
-    // TODO: Animation, TripleStateCheckbox
+    TriStateCheckBox(
+        state = if (checked) ToggleableState.On else ToggleableState.Off,
+        label = label,
+        modifier = modifier,
+        enabled = enabled,
+        colors = colors,
+        onClick = { onCheckStateChange(!checked) }
+    )
+}
+
+/**
+ * A composable function that renders a tri-state CheckBox with an optional label.
+ *
+ * [onClick] is responsible for updating [state]. This allows callers to decide how an
+ * indeterminate state should transition instead of treating it as a third selectable option.
+ *
+ * @param state The current state of the checkbox.
+ * @param label The optional label to display next to the checkbox.
+ * @param modifier Modifier to be applied to the row containing the checkbox and label.
+ * @param enabled Whether the checkbox is enabled.
+ * @param colors The color scheme to use for the checkbox.
+ * @param onClick Callback invoked when the checkbox is clicked, or `null` for a non-interactive checkbox.
+ */
+@Composable
+fun TriStateCheckBox(
+    state: ToggleableState,
+    label: String? = null,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: VisualStateScheme<CheckBoxColor> = if (state == ToggleableState.Off) {
+        CheckBoxDefaults.defaultCheckBoxColors()
+    } else {
+        CheckBoxDefaults.selectedCheckBoxColors()
+    },
+    onClick: (() -> Unit)?
+) {
     val interactionSource = remember { MutableInteractionSource() }
     val color = colors.schemeFor(interactionSource.collectVisualState(!enabled))
+    val iconTransition = remember { CheckBoxIconTransition(state) }
+    iconTransition.update(state)
+
+    val interactionModifier = if (onClick != null) {
+        Modifier.triStateToggleable(
+            state = state,
+            enabled = enabled,
+            role = Role.Checkbox,
+            interactionSource = interactionSource,
+            indication = null,
+            onClick = onClick
+        )
+    } else {
+        Modifier.semantics(mergeDescendants = true) {
+            toggleableState = state
+            role = Role.Checkbox
+            if (!enabled) disabled()
+        }
+    }
+
     Row(
         modifier = modifier.then(
             if (label != null) Modifier.defaultMinSize(minWidth = 120.dp)
             else Modifier
-        ).clickable(
-            role = Role.Checkbox,
-            indication = null,
-            interactionSource = interactionSource
-        ) { onCheckStateChange(!checked) },
+        ).then(interactionModifier),
         verticalAlignment = Alignment.CenterVertically
     ) {
         val fillColor by animateColorAsState(color.fillColor,
@@ -80,16 +139,41 @@ fun CheckBox(
             color = fillColor,
             contentColor = color.contentColor,
             border = BorderStroke(1.dp, color.borderColor),
-            backgroundSizing = if (!checked) BackgroundSizing.InnerBorderEdge else BackgroundSizing.OuterBorderEdge
+            backgroundSizing = if (state == ToggleableState.Off) {
+                BackgroundSizing.InnerBorderEdge
+            } else {
+                BackgroundSizing.OuterBorderEdge
+            }
         ) {
             Box(contentAlignment = Alignment.CenterStart) {
+                if (state == ToggleableState.Indeterminate) {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Box(
+                            Modifier
+                                .size(width = 8.dp, height = 1.dp)
+                                .background(
+                                    color = color.contentColor,
+                                    shape = androidx.compose.foundation.shape.RoundedCornerShape(50)
+                                )
+                        )
+                    }
+                }
                 androidx.compose.animation.AnimatedVisibility(
-                    visible = checked,
-                    enter = expandHorizontally(
-                        expandFrom = Alignment.Start
-                    ), exit = fadeOut(
-                        tween(durationMillis = FluentDuration.QuickDuration, easing = FluentEasing.FadeInFadeOutEasing)
-                    )
+                    visible = state == ToggleableState.On,
+                    enter = if (iconTransition.animate) {
+                        expandHorizontally(
+                            expandFrom = Alignment.Start
+                        )
+                    } else {
+                        EnterTransition.None
+                    },
+                    exit = if (iconTransition.animate) {
+                        fadeOut(
+                            tween(durationMillis = FluentDuration.QuickDuration, easing = FluentEasing.FadeInFadeOutEasing)
+                        )
+                    } else {
+                        ExitTransition.None
+                    }
                 ) {
                     Box(Modifier.fillMaxSize(), Alignment.Center) {
                         FontIcon(
@@ -110,6 +194,19 @@ fun CheckBox(
                 style = FluentTheme.typography.body.copy(color = color.labelTextColor)
             )
         }
+    }
+}
+
+private class CheckBoxIconTransition(initialState: ToggleableState) {
+    private var state = initialState
+    var animate = initialState != ToggleableState.Indeterminate
+        private set
+
+    fun update(newState: ToggleableState) {
+        if (newState == state) return
+        animate = state != ToggleableState.Indeterminate &&
+                newState != ToggleableState.Indeterminate
+        state = newState
     }
 }
 

--- a/gallery/sharedApp/src/commonMain/kotlin/io/github/composefluent/gallery/screen/basicinput/CheckBoxScreen.kt
+++ b/gallery/sharedApp/src/commonMain/kotlin/io/github/composefluent/gallery/screen/basicinput/CheckBoxScreen.kt
@@ -1,17 +1,25 @@
 package io.github.composefluent.gallery.screen.basicinput
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.unit.dp
 import io.github.composefluent.component.CheckBox
 import io.github.composefluent.component.Text
+import io.github.composefluent.component.TriStateCheckBox
 import io.github.composefluent.gallery.annotation.Component
 import io.github.composefluent.gallery.annotation.Sample
 import io.github.composefluent.gallery.component.ComponentPagePath
 import io.github.composefluent.gallery.component.GalleryPage
-import io.github.composefluent.gallery.component.TodoComponent
 import io.github.composefluent.source.generated.FluentSourceFile
 
 @Component(index = 7, description = "A control that a user can select or clear.")
@@ -45,12 +53,35 @@ fun CheckBoxScreen() {
                 Text(twoStateOutput.value)
             }
         )
-        Section("A 3-state CheckBox.", "") {
-            TodoComponent()
-        }
-        Section("Using a 3-state CheckBox", "") {
-            TodoComponent()
-        }
+
+        var threeState by remember { mutableStateOf(ToggleableState.Off) }
+        val threeStateOutput = remember { mutableStateOf("") }
+        Section(
+            title = "A 3-state CheckBox.",
+            sourceCode = sourceCodeOfThreeStateCheckBoxSample,
+            content = {
+                ThreeStateCheckBoxSample(
+                    toggleableState = threeState,
+                    onToggleableStateChanged = {
+                        threeState = it
+                        threeStateOutput.value = "CheckBox is " + when(it) {
+                            ToggleableState.On -> "checked"
+                            ToggleableState.Off -> "unchecked"
+                            ToggleableState.Indeterminate -> "indeterminate"
+                        } + "."
+                    }
+                )
+            },
+            output = {
+                Text(threeStateOutput.value)
+            }
+        )
+
+        Section(
+            title = "Using a 3-state CheckBox",
+            sourceCode = sourceCodeOfParentCheckBoxSample,
+            content = { ParentCheckBoxSample() }
+        )
     }
 }
 
@@ -59,4 +90,58 @@ fun CheckBoxScreen() {
 private fun TwoStateCheckBoxSample(checked: Boolean, onCheckedChanged: (Boolean) -> Unit) {
 
     CheckBox(checked, "Two-state CheckBox", onCheckStateChange = onCheckedChanged)
+}
+
+@Sample
+@Composable
+private fun ThreeStateCheckBoxSample(toggleableState: ToggleableState, onToggleableStateChanged: (ToggleableState) -> Unit) {
+
+    TriStateCheckBox(
+        state = toggleableState,
+        label = "Three-state CheckBox",
+        onClick = {
+            val nextState = when (toggleableState) {
+                ToggleableState.Off -> ToggleableState.On
+                ToggleableState.On -> ToggleableState.Indeterminate
+                ToggleableState.Indeterminate -> ToggleableState.Off
+            }
+            onToggleableStateChanged(nextState)
+        }
+    )
+}
+
+@Sample
+@Composable
+private fun ParentCheckBoxSample() {
+    val checkedItems = remember { mutableStateListOf(false, true, false) }
+    val parentState by remember(checkedItems) {
+        derivedStateOf {
+            when(checkedItems.sumOf { if (it) 1 else 0 }) {
+                checkedItems.size -> ToggleableState.On
+                0 -> ToggleableState.Off
+                else -> ToggleableState.Indeterminate
+            }
+        }
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        TriStateCheckBox(
+            state = parentState,
+            label = "Select all",
+            onClick = {
+                val targetState = parentState != ToggleableState.Off
+                checkedItems.forEachIndexed { index, _ ->
+                    checkedItems[index] = !targetState
+                }
+            }
+        )
+        checkedItems.forEachIndexed { index, value ->
+            CheckBox(
+                checked = value,
+                label = "Option ${index + 1}",
+                onCheckStateChange = { checkedItems[index] = it },
+                modifier = Modifier.padding(start = 24.dp)
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- add an externally controlled `TriStateCheckBox` API based on Compose `ToggleableState`
- keep the existing two-state `CheckBox` API source-compatible by delegating to the shared tri-state implementation
- preserve the existing `On` and `Off` visuals and animation behavior
- render `Indeterminate` as a centered 8 × 1 dp rounded bar and disable icon animation for transitions entering or leaving that state
- add Gallery examples for standalone three-state behavior and parent/child selection
- mark TriState Check Box as implemented in the README

## Impact

Consumers can now represent checked, unchecked, and indeterminate selection state while retaining the existing Fluent CheckBox styling and accessibility semantics. State transitions remain caller-controlled, matching the Material 3 API model.

## Validation

- `./gradlew :fluent:compileKotlinJvm :gallery:sharedApp:compileKotlinJvm`

No tests were added or run for this change.
