### PR TITLE
feat: add TreeViewItem component and Gallery samples

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/TreeViewItem.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/TreeViewItem.kt
@@ -1,0 +1,534 @@
+package io.github.composefluent.component
+
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.constrainHeight
+import androidx.compose.ui.unit.constrainWidth
+import androidx.compose.ui.unit.dp
+import io.github.composefluent.FluentTheme
+import io.github.composefluent.animation.FluentDuration
+import io.github.composefluent.animation.FluentEasing
+import io.github.composefluent.background.BackgroundSizing
+import io.github.composefluent.background.Layer
+import io.github.composefluent.scheme.VisualStateScheme
+import io.github.composefluent.scheme.collectVisualState
+import kotlin.math.roundToInt
+
+/**
+ * A compact, selectable item for a caller-owned tree or flattened tree list.
+ *
+ * The nullable [checkbox] slot selects the leading selection presentation. When it is null,
+ * the standard [ListItemDefaults.Indicator] is shown. When it is supplied, the slot replaces the
+ * indicator and animates into the content row. The checkbox content and its state remain owned by
+ * the caller; [selected] always controls the row's selected colors.
+ *
+ * This overload represents a leaf item. It reserves the chevron slot for alignment, but does not
+ * expose an expansion action.
+ *
+ * @param selected Whether this item is selected.
+ * @param onClick Called when the row is clicked.
+ * @param text The primary text content of the item.
+ * @param modifier Modifier applied to the item.
+ * @param level Hierarchy level. Each level adds 16.dp of leading indentation; negative values are
+ * coerced to zero.
+ * @param checkbox Optional caller-owned checkbox content.
+ * @param icon Optional icon displayed after the chevron.
+ * @param interactionSource Optional interaction source used by the row.
+ * @param enabled Whether the row can be clicked.
+ * @param colors Colors used for the row's interaction states.
+ */
+@Composable
+fun TreeViewItem(
+    selected: Boolean,
+    onClick: () -> Unit,
+    text: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    level: Int = 0,
+    checkbox: (@Composable () -> Unit)? = null,
+    icon: (@Composable () -> Unit)? = null,
+    interactionSource: MutableInteractionSource? = null,
+    enabled: Boolean = true,
+    colors: VisualStateScheme<ListItemColor> = if (selected) {
+        ListItemDefaults.selectedListItemColors()
+    } else {
+        ListItemDefaults.defaultListItemColors()
+    },
+) {
+    TreeViewItemImpl(
+        selected = selected,
+        onClick = onClick,
+        text = text,
+        modifier = modifier,
+        level = level,
+        checkbox = checkbox,
+        icon = icon,
+        interactionSource = interactionSource,
+        enabled = enabled,
+        colors = colors,
+        expanded = null,
+        onExpandedChanged = null,
+    )
+}
+
+/**
+ * A compact, selectable and expandable item for a caller-owned tree or flattened tree list.
+ *
+ * This overload represents an item with children. The chevron has an independent click target
+ * and does not invoke the row's [onClick].
+ *
+ * @param selected Whether this item is selected.
+ * @param onClick Called when the row is clicked.
+ * @param expanded Whether the child items are currently visible.
+ * @param onExpandedChanged Called with the new expanded state when the chevron is clicked.
+ * @param text The primary text content of the item.
+ * @param modifier Modifier applied to the item.
+ * @param level Hierarchy level. Each level adds 16.dp of leading indentation; negative values are
+ * coerced to zero.
+ * @param checkbox Optional caller-owned checkbox content.
+ * @param icon Optional icon displayed after the chevron.
+ * @param interactionSource Optional interaction source shared by the row and expansion action.
+ * @param enabled Whether the row and chevron can be interacted with.
+ * @param colors Colors used for the row's interaction states.
+ */
+@Composable
+fun TreeViewItem(
+    selected: Boolean,
+    onClick: () -> Unit,
+    expanded: Boolean,
+    onExpandedChanged: (Boolean) -> Unit,
+    text: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    level: Int = 0,
+    checkbox: (@Composable () -> Unit)? = null,
+    icon: (@Composable () -> Unit)? = null,
+    interactionSource: MutableInteractionSource? = null,
+    enabled: Boolean = true,
+    colors: VisualStateScheme<ListItemColor> = if (selected) {
+        ListItemDefaults.selectedListItemColors()
+    } else {
+        ListItemDefaults.defaultListItemColors()
+    },
+) {
+    TreeViewItemImpl(
+        selected = selected,
+        onClick = onClick,
+        text = text,
+        modifier = modifier,
+        level = level,
+        checkbox = checkbox,
+        icon = icon,
+        interactionSource = interactionSource,
+        enabled = enabled,
+        colors = colors,
+        expanded = expanded,
+        onExpandedChanged = onExpandedChanged,
+    )
+}
+
+@Composable
+private fun TreeViewItemImpl(
+    selected: Boolean,
+    onClick: () -> Unit,
+    text: @Composable () -> Unit,
+    modifier: Modifier,
+    level: Int,
+    checkbox: (@Composable () -> Unit)?,
+    icon: (@Composable () -> Unit)?,
+    interactionSource: MutableInteractionSource?,
+    enabled: Boolean,
+    colors: VisualStateScheme<ListItemColor>,
+    expanded: Boolean?,
+    onExpandedChanged: ((Boolean) -> Unit)?,
+) {
+    val actualInteraction = interactionSource ?: remember { MutableInteractionSource() }
+    val color = colors.schemeFor(actualInteraction.collectVisualState(!enabled))
+    val fillColor by androidx.compose.animation.animateColorAsState(
+        targetValue = color.fillColor,
+        animationSpec = tween(
+            durationMillis = FluentDuration.QuickDuration,
+            easing = FluentEasing.FastInvokeEasing
+        )
+    )
+    val contentColor by androidx.compose.animation.animateColorAsState(
+        targetValue = color.contentColor,
+        animationSpec = tween(
+            durationMillis = FluentDuration.QuickDuration,
+            easing = FluentEasing.FastInvokeEasing
+        )
+    )
+    val indentation = TreeViewItemDefaults.levelIndent * level.coerceAtLeast(0)
+
+    Layer(
+        modifier = modifier
+            .defaultMinSize(minWidth = 108.dp, minHeight = TreeViewItemDefaults.compactHeight)
+            .padding(horizontal = 5.dp, vertical = 2.dp)
+            .fillMaxWidth(),
+        shape = FluentTheme.shapes.control,
+        color = fillColor,
+        contentColor = contentColor,
+        border = BorderStroke(1.dp, color.borderBrush),
+        backgroundSizing = BackgroundSizing.OuterBorderEdge,
+    ) {
+        TreeViewItemLayout(
+            selected = selected,
+            onClick = onClick,
+            text = text,
+            indentation = indentation,
+            checkbox = checkbox,
+            icon = icon,
+            interactionSource = actualInteraction,
+            enabled = enabled,
+            expanded = expanded,
+            onExpandedChanged = onExpandedChanged,
+        )
+    }
+}
+
+@Composable
+private fun TreeViewItemLayout(
+    selected: Boolean,
+    onClick: () -> Unit,
+    text: @Composable () -> Unit,
+    indentation: Dp,
+    checkbox: (@Composable () -> Unit)?,
+    icon: (@Composable () -> Unit)?,
+    interactionSource: MutableInteractionSource,
+    enabled: Boolean,
+    expanded: Boolean?,
+    onExpandedChanged: ((Boolean) -> Unit)?,
+) {
+    val hasCheckbox = checkbox != null
+    val hasExpansionTarget = expanded != null && onExpandedChanged != null
+    val checkboxTransition = updateTransition(targetState = hasCheckbox)
+    val checkboxWidthFraction = checkboxTransition.animateFloat(
+        transitionSpec = {
+            if (targetState) {
+                tween(
+                    durationMillis = FluentDuration.ShortDuration,
+                    easing = FluentEasing.FastInvokeEasing,
+                )
+            } else {
+                tween(
+                    durationMillis = FluentDuration.QuickDuration,
+                    easing = FluentEasing.SoftDismissEasing,
+                )
+            }
+        },
+        targetValueByState = { visible -> if (visible) 1f else 0f },
+    )
+    val checkboxAlpha = checkboxTransition.animateFloat(
+        transitionSpec = {
+            tween(
+                durationMillis = FluentDuration.QuickDuration,
+                easing = FluentEasing.FadeInFadeOutEasing,
+            )
+        },
+        targetValueByState = { visible -> if (visible) 1f else 0f },
+    )
+    val contentHolder = remember { CheckboxContentHolder() }
+    if (checkbox != null) {
+        contentHolder.content = checkbox
+    } else if (!checkboxTransition.currentState && !checkboxTransition.targetState) {
+        contentHolder.content = null
+    }
+
+    Layout(
+        modifier = Modifier.selectable(
+            selected = selected,
+            enabled = enabled,
+            interactionSource = interactionSource,
+            indication = null,
+            onClick = onClick,
+        ),
+        content = {
+            ListItemDefaults.Indicator(
+                visible = selected && !hasCheckbox,
+                enabled = enabled,
+            )
+            Box(
+                modifier = Modifier
+                    .size(TreeViewItemDefaults.checkboxSize)
+                    .graphicsLayer {
+                        val fraction = checkboxWidthFraction.value
+                        val scale = TreeViewItemCheckboxInitialScale +
+                            (1f - TreeViewItemCheckboxInitialScale) * fraction
+                        scaleX = scale
+                        scaleY = scale
+                        alpha = checkboxAlpha.value
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                contentHolder.content?.invoke()
+            }
+            ExpandChevron(expanded = expanded)
+            if (icon != null) {
+                Box(
+                    modifier = Modifier.size(ListItemDefaults.iconSize),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    icon()
+                }
+            }
+            Box(contentAlignment = Alignment.CenterStart) {
+                text()
+            }
+            if (expanded != null && onExpandedChanged != null) {
+                ExpandChevronClickTarget(
+                    expanded = expanded,
+                    enabled = enabled,
+                    onExpandedChanged = onExpandedChanged,
+                )
+            }
+        },
+        measurePolicy = remember(
+            indentation,
+            hasCheckbox,
+            icon != null,
+            hasExpansionTarget,
+            checkboxWidthFraction,
+        ) {
+            TreeViewItemMeasurePolicy(
+                indentation = indentation,
+                hasCheckbox = hasCheckbox,
+                hasIcon = icon != null,
+                hasExpansionTarget = hasExpansionTarget,
+                checkboxWidthFraction = checkboxWidthFraction,
+            )
+        },
+    )
+}
+
+@Composable
+private fun ExpandChevron(expanded: Boolean?) {
+    if (expanded == null) {
+        Box(modifier = Modifier.size(TreeViewItemDefaults.chevronSize))
+        return
+    }
+    val layoutDirection = LocalLayoutDirection.current
+    val rotation by animateFloatAsState(
+        targetValue = when {
+            expanded -> 90f
+            layoutDirection == LayoutDirection.Rtl -> 180f
+            else -> 0f
+        },
+        animationSpec = tween(
+            durationMillis = FluentDuration.ShortDuration,
+            easing = FluentEasing.FastInvokeEasing,
+        ),
+    )
+    Box(
+        modifier = Modifier
+            .size(TreeViewItemDefaults.chevronSize)
+            .graphicsLayer { rotationZ = rotation },
+        contentAlignment = Alignment.Center,
+    ) {
+        FontIcon(
+            type = FontIconPrimitive.ChevronRight,
+            contentDescription = null,
+            size = FontIconSize.Small,
+        )
+    }
+}
+
+@Composable
+private fun ExpandChevronClickTarget(
+    expanded: Boolean,
+    enabled: Boolean,
+    onExpandedChanged: (Boolean) -> Unit,
+) {
+    val description = if (expanded) "Collapse" else "Expand"
+
+    Box(
+        modifier = Modifier
+            .semantics {
+                contentDescription = description
+            }
+            .clickable(
+                enabled = enabled,
+                role = Role.Button,
+                interactionSource = null,
+                indication = null,
+                onClick = { onExpandedChanged(!expanded) },
+            ),
+    )
+}
+
+private class CheckboxContentHolder {
+    var content: (@Composable () -> Unit)? = null
+}
+
+private class TreeViewItemMeasurePolicy(
+    private val indentation: Dp,
+    private val hasCheckbox: Boolean,
+    private val hasIcon: Boolean,
+    private val hasExpansionTarget: Boolean,
+    private val checkboxWidthFraction: State<Float>,
+) : MeasurePolicy {
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+        var index = 0
+        val indicator = measurables[index++].measure(looseConstraints)
+        val checkbox = measurables[index++].measure(looseConstraints)
+        val chevron = measurables[index++].measure(looseConstraints)
+        val icon = if (hasIcon) {
+            measurables[index++].measure(looseConstraints)
+        } else {
+            null
+        }
+        val textMeasurable = measurables[index++]
+        val expansionTargetMeasurable = if (hasExpansionTarget) {
+            measurables[index]
+        } else {
+            null
+        }
+
+        val indentationPx = indentation.roundToPx().coerceAtLeast(0)
+        val rowStartPaddingPx = TreeViewItemRowStartPadding.roundToPx()
+        val checkboxAnimationFraction = checkboxWidthFraction.value.coerceIn(0f, 1f)
+        val animatedCheckboxWidth = (checkbox.width * checkboxAnimationFraction).roundToInt()
+        val checkboxSpacingPx =
+            (TreeViewItemCheckboxSpacing.toPx() * checkboxAnimationFraction).roundToInt()
+        val chevronStartPaddingPx = TreeViewItemChevronStartPadding.roundToPx()
+        val chevronEndPaddingPx = TreeViewItemChevronEndPadding.roundToPx()
+        val iconEndPaddingPx = TreeViewItemIconEndPadding.roundToPx()
+        val rowEndPaddingPx = TreeViewItemRowEndPadding.roundToPx()
+
+        var position = addWidths(indentationPx, rowStartPaddingPx)
+        val checkboxPosition = position
+        position = addWidths(position, animatedCheckboxWidth)
+        val expansionStart = if (hasCheckbox) {
+            addWidths(checkboxPosition, checkbox.width)
+        } else {
+            indentationPx
+        }
+        position = addWidths(position, checkboxSpacingPx)
+        position = addWidths(position, chevronStartPaddingPx)
+        val chevronPosition = position
+        position = addWidths(position, chevron.width)
+        position = addWidths(position, chevronEndPaddingPx)
+        val expansionEnd = position
+        val iconPosition = position
+        if (icon != null) {
+            position = addWidths(position, icon.width)
+            position = addWidths(position, iconEndPaddingPx)
+        }
+        val textPosition = position
+
+        val text = if (constraints.hasBoundedWidth) {
+            val availableWidth = (
+                constraints.maxWidth - textPosition.coerceAtMost(constraints.maxWidth) -
+                    rowEndPaddingPx.coerceAtMost(constraints.maxWidth)
+                ).coerceAtLeast(0)
+            textMeasurable.measure(
+                looseConstraints.copy(
+                    minWidth = availableWidth,
+                    maxWidth = availableWidth,
+                )
+            )
+        } else {
+            textMeasurable.measure(looseConstraints)
+        }
+        val desiredWidth = addWidths(
+            addWidths(textPosition, text.width),
+            rowEndPaddingPx,
+        )
+        val layoutWidth = if (constraints.hasBoundedWidth) {
+            constraints.maxWidth
+        } else {
+            constraints.constrainWidth(desiredWidth)
+        }
+        val layoutHeight = constraints.constrainHeight(
+            maxOf(
+                indicator.height,
+                checkbox.height,
+                chevron.height,
+                icon?.height ?: 0,
+                text.height,
+            )
+        )
+        val targetStart = expansionStart.coerceIn(0, layoutWidth)
+        val targetEnd = expansionEnd.coerceIn(targetStart, layoutWidth)
+        val expansionTarget = expansionTargetMeasurable?.measure(
+            Constraints.fixed(
+                width = targetEnd - targetStart,
+                height = layoutHeight,
+            )
+        )
+
+        return layout(layoutWidth, layoutHeight) {
+            indicator.placeRelative(
+                x = 0,
+                y = Alignment.CenterVertically.align(indicator.height, layoutHeight),
+            )
+            checkbox.placeRelative(
+                x = checkboxPosition,
+                y = Alignment.CenterVertically.align(checkbox.height, layoutHeight),
+            )
+            chevron.placeRelative(
+                x = chevronPosition,
+                y = Alignment.CenterVertically.align(chevron.height, layoutHeight),
+            )
+            icon?.placeRelative(
+                x = iconPosition,
+                y = Alignment.CenterVertically.align(icon.height, layoutHeight),
+            )
+            text.placeRelative(
+                x = textPosition,
+                y = Alignment.CenterVertically.align(text.height, layoutHeight),
+            )
+            expansionTarget?.placeRelative(targetStart, 0)
+        }
+    }
+}
+
+private fun addWidths(first: Int, second: Int): Int =
+    if (first > Int.MAX_VALUE - second) Int.MAX_VALUE else first + second
+
+private val TreeViewItemCheckboxSpacing = 4.dp
+private val TreeViewItemRowStartPadding = 10.dp
+private val TreeViewItemRowEndPadding = 10.dp
+private val TreeViewItemChevronStartPadding = 8.dp
+private val TreeViewItemChevronEndPadding = 14.dp
+private val TreeViewItemIconEndPadding = 12.dp
+private const val TreeViewItemCheckboxInitialScale = 0.8f
+
+/** Default dimensions used by [TreeViewItem]. */
+object TreeViewItemDefaults {
+    val levelIndent = 16.dp
+    val compactHeight = 32.dp
+    val checkboxSize = 20.dp
+    val chevronSize = 16.dp
+}

--- a/gallery/sharedApp/src/commonMain/kotlin/io/github/composefluent/gallery/screen/collections/TreeViewItemScreen.kt
+++ b/gallery/sharedApp/src/commonMain/kotlin/io/github/composefluent/gallery/screen/collections/TreeViewItemScreen.kt
@@ -1,0 +1,435 @@
+package io.github.composefluent.gallery.screen.collections
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateSetOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.composefluent.component.CheckBox
+import io.github.composefluent.component.Icon
+import io.github.composefluent.component.Text
+import io.github.composefluent.component.TreeViewItem
+import io.github.composefluent.component.TriStateCheckBox
+import io.github.composefluent.gallery.annotation.Component
+import io.github.composefluent.gallery.annotation.Sample
+import io.github.composefluent.gallery.component.ComponentPagePath
+import io.github.composefluent.gallery.component.GalleryPage
+import io.github.composefluent.icons.Icons
+import io.github.composefluent.icons.regular.Document
+import io.github.composefluent.icons.regular.Folder
+import io.github.composefluent.source.generated.FluentSourceFile
+
+private data class TreeNode(
+    val id: String,
+    val title: String,
+    val children: List<TreeNode> = emptyList(),
+)
+
+private data class TreeNodePosition(
+    val parentId: String?,
+    val index: Int,
+)
+
+private val treeViewSampleNodes = listOf(
+    TreeNode(
+        id = "work-documents",
+        title = "Work Documents",
+        children = listOf(
+            TreeNode("xyz-functional-spec", "XYZ Functional Spec"),
+            TreeNode("feature-schedule", "Feature Schedule"),
+        ),
+    ),
+    TreeNode(
+        id = "personal-documents",
+        title = "Personal Documents",
+        children = listOf(
+            TreeNode(
+                id = "home-remodel",
+                title = "Home Remodel",
+                children = listOf(
+                    TreeNode("contractor-contact-info", "Contractor Contact Info"),
+                    TreeNode("paint-color-scheme", "Paint Color Scheme"),
+                ),
+            ),
+        ),
+    ),
+)
+
+private val treeViewSampleExpandedIds = buildSet {
+    fun addParentIds(nodes: List<TreeNode>) {
+        nodes.forEach { node ->
+            if (node.children.isNotEmpty()) {
+                add(node.id)
+                addParentIds(node.children)
+            }
+        }
+    }
+    addParentIds(treeViewSampleNodes)
+}
+
+private val treeViewSampleNodePositions = buildMap {
+    fun indexNodes(nodes: List<TreeNode>, parentId: String?) {
+        nodes.forEachIndexed { index, node ->
+            put(node.id, TreeNodePosition(parentId = parentId, index = index))
+            indexNodes(node.children, parentId = node.id)
+        }
+    }
+
+    indexNodes(treeViewSampleNodes, parentId = null)
+}
+
+private fun LazyListScope.treeViewSampleItems(
+    expandedIds: Set<String>,
+    itemContent: @Composable LazyItemScope.(node: TreeNode, level: Int) -> Unit,
+) {
+    val expandedNodeIndicesByParent = mutableMapOf<String?, MutableList<Int>>()
+    expandedIds.forEach { nodeId ->
+        val position = treeViewSampleNodePositions[nodeId] ?: return@forEach
+        expandedNodeIndicesByParent
+            .getOrPut(position.parentId) { mutableListOf() }
+            .add(position.index)
+    }
+    expandedNodeIndicesByParent.values.forEach { indices -> indices.sort() }
+
+    fun addRange(nodes: List<TreeNode>, level: Int, startIndex: Int, endIndex: Int) {
+        val count = endIndex - startIndex
+        if (count <= 0) return
+        this@treeViewSampleItems.items(
+            count = count,
+            key = { offset -> nodes[startIndex + offset].id },
+        ) { offset ->
+            itemContent(nodes[startIndex + offset], level)
+        }
+    }
+
+    fun addNodes(nodes: List<TreeNode>, parentId: String?, level: Int) {
+        var rangeStart = 0
+        expandedNodeIndicesByParent[parentId].orEmpty().forEach { expandedIndex ->
+            if (expandedIndex !in rangeStart..<nodes.size) return@forEach
+            addRange(nodes, level, rangeStart, expandedIndex)
+            val node = nodes[expandedIndex]
+            addRange(nodes, level, expandedIndex, expandedIndex + 1)
+            addNodes(node.children, parentId = node.id, level = level + 1)
+            rangeStart = expandedIndex + 1
+        }
+        addRange(nodes, level, rangeStart, nodes.size)
+    }
+
+    addNodes(treeViewSampleNodes, parentId = null, level = 0)
+}
+
+private val treeViewSampleLeafIdsByNodeId = buildMap {
+    fun indexNode(node: TreeNode): Set<String> {
+        val leafIds = if (node.children.isEmpty()) {
+            setOf(node.id)
+        } else {
+            node.children.flatMap { child -> indexNode(child) }.toSet()
+        }
+        put(node.id, leafIds)
+        return leafIds
+    }
+
+    treeViewSampleNodes.forEach { node -> indexNode(node) }
+}
+
+private fun TreeNode.descendantLeafIds(): Set<String> = treeViewSampleLeafIdsByNodeId[id].orEmpty()
+
+private fun treeViewSampleCheckboxState(
+    node: TreeNode,
+    checkedLeafIds: Set<String>,
+): ToggleableState {
+    val descendantLeafIds = node.descendantLeafIds()
+    val checkedCount = descendantLeafIds.count(checkedLeafIds::contains)
+    return when {
+        descendantLeafIds.isEmpty() || checkedCount == 0 -> ToggleableState.Off
+        checkedCount == descendantLeafIds.size -> ToggleableState.On
+        else -> ToggleableState.Indeterminate
+    }
+}
+
+@Component(description = "Compact, hierarchical items for caller-owned tree lists.")
+@Composable
+fun TreeViewItemScreen() {
+    GalleryPage(
+        title = "TreeViewItem",
+        description = "Compact hierarchical list items with expansion, selection, icons, and optional checkboxes.",
+        componentPath = FluentSourceFile.TreeViewItem,
+        galleryPath = ComponentPagePath.TreeViewItemScreen,
+    ) {
+        Section(
+            title = "Standard TreeViewItem",
+            sourceCode = sourceCodeOfStandardTreeViewItemSample,
+            content = { StandardTreeViewItemSample() },
+        )
+        Section(
+            title = "TreeViewItem with checkbox states",
+            sourceCode = sourceCodeOfCheckboxTreeViewItemSample,
+            content = { CheckboxTreeViewItemSample() },
+        )
+        val showCheckbox = remember { mutableStateOf(false) }
+        val showIcon = remember { mutableStateOf(true) }
+        val enabled = remember { mutableStateOf(true) }
+        Section(
+            title = "TreeViewItem Options Sample",
+            sourceCode = sourceCodeOfTreeViewItemOptionsSample,
+            options = {
+                CheckBox(
+                    checked = showCheckbox.value,
+                    onCheckStateChange = { showCheckbox.value = it },
+                    label = "Checkbox",
+                )
+                CheckBox(
+                    checked = showIcon.value,
+                    onCheckStateChange = { showIcon.value = it },
+                    label = "Icon",
+                )
+                CheckBox(
+                    checked = enabled.value,
+                    onCheckStateChange = { enabled.value = it },
+                    label = "Enabled",
+                )
+            },
+            content = {
+                TreeViewItemOptionsSample(
+                    showCheckbox = showCheckbox.value,
+                    showIcon = showIcon.value,
+                    enabled = enabled.value,
+                )
+            },
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun StandardTreeViewItemSample() {
+    val expandedIds = remember { mutableStateSetOf<String>().also { it.addAll(treeViewSampleExpandedIds) } }
+    var selectedId by remember { mutableStateOf<String?>(null) }
+
+    LazyColumn(modifier = Modifier.height(220.dp).widthIn(max = TreeViewListMaxWidth)) {
+        treeViewSampleItems(expandedIds) { node, level ->
+            val icon = if (node.children.isNotEmpty()) Icons.Default.Folder else Icons.Default.Document
+            if (node.children.isNotEmpty()) {
+                TreeViewItem(
+                    selected = selectedId == node.id,
+                    onClick = {
+                        selectedId = if (selectedId == node.id) null else node.id
+                    },
+                    expanded = node.id in expandedIds,
+                    onExpandedChanged = { expanded ->
+                        if (expanded) {
+                            expandedIds += node.id
+                        } else {
+                            expandedIds -= node.id
+                        }
+                    },
+                    level = level,
+                    icon = { Icon(icon, contentDescription = null) },
+                    text = { Text(text = node.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                    modifier = Modifier.fillMaxWidth().animateItem(),
+                )
+            } else {
+                TreeViewItem(
+                    selected = selectedId == node.id,
+                    onClick = {
+                        selectedId = if (selectedId == node.id) null else node.id
+                    },
+                    level = level,
+                    icon = { Icon(icon, contentDescription = null) },
+                    text = { Text(text = node.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                    modifier = Modifier.fillMaxWidth().animateItem(),
+                )
+            }
+        }
+    }
+}
+
+@Sample
+@Composable
+private fun CheckboxTreeViewItemSample() {
+    val expandedIds = remember { mutableStateSetOf<String>().also { it.addAll(treeViewSampleExpandedIds) } }
+    val checkedLeafIds = remember { mutableStateSetOf("feature-schedule") }
+
+    LazyColumn(modifier = Modifier.height(220.dp).widthIn(max = TreeViewListMaxWidth)) {
+        treeViewSampleItems(expandedIds) { node, level ->
+            val icon = if (node.children.isNotEmpty()) Icons.Default.Folder else Icons.Default.Document
+            val parentState = if (node.children.isNotEmpty()) {
+                treeViewSampleCheckboxState(node, checkedLeafIds)
+            } else {
+                null
+            }
+            if (node.children.isNotEmpty()) {
+                TreeViewItem(
+                    selected = parentState == ToggleableState.On,
+                    onClick = {},
+                    expanded = node.id in expandedIds,
+                    onExpandedChanged = { expanded ->
+                        if (expanded) {
+                            expandedIds += node.id
+                        } else {
+                            expandedIds -= node.id
+                        }
+                    },
+                    level = level,
+                    checkbox = {
+                        TriStateCheckBox(
+                            state = parentState ?: ToggleableState.Off,
+                            onClick = {
+                                val descendantLeafIds = node.descendantLeafIds()
+                                val shouldCheck = parentState == ToggleableState.Off
+                                if (shouldCheck) {
+                                    checkedLeafIds += descendantLeafIds
+                                } else {
+                                    checkedLeafIds -= descendantLeafIds.toSet()
+                                }
+                            },
+                        )
+                    },
+                    icon = { Icon(icon, contentDescription = null) },
+                    text = { Text(text = node.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                    modifier = Modifier.fillMaxWidth().animateItem(),
+                )
+            } else {
+                TreeViewItem(
+                    selected = node.id in checkedLeafIds,
+                    onClick = {},
+                    level = level,
+                    checkbox = {
+                        CheckBox(
+                            checked = node.id in checkedLeafIds,
+                            onCheckStateChange = { checked ->
+                                if (checked) {
+                                    checkedLeafIds += node.id
+                                } else {
+                                    checkedLeafIds -= node.id
+                                }
+                            },
+                        )
+                    },
+                    icon = { Icon(icon, contentDescription = null) },
+                    text = { Text(text = node.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                    modifier = Modifier.fillMaxWidth().animateItem(),
+                )
+            }
+        }
+    }
+}
+
+@Sample
+@Composable
+private fun TreeViewItemOptionsSample(
+    showCheckbox: Boolean,
+    showIcon: Boolean,
+    enabled: Boolean,
+) {
+    val expandedIds = remember { mutableStateSetOf<String>().also { it.addAll(treeViewSampleExpandedIds) } }
+    var selectedId by remember { mutableStateOf<String?>(null) }
+    val checkedLeafIds = remember { mutableStateSetOf<String>() }
+
+    LazyColumn(modifier = Modifier.height(220.dp).widthIn(max = TreeViewListMaxWidth)) {
+        treeViewSampleItems(expandedIds) { node, level ->
+            val icon = if (node.children.isNotEmpty()) Icons.Default.Folder else Icons.Default.Document
+            val iconContent: (@Composable () -> Unit)? = if (showIcon) {
+                { Icon(icon, contentDescription = null) }
+            } else {
+                null
+            }
+            val parentState = if (node.children.isNotEmpty()) {
+                treeViewSampleCheckboxState(node, checkedLeafIds)
+            } else {
+                null
+            }
+            val checkboxContent: (@Composable () -> Unit)? = if (showCheckbox) {
+                if (node.children.isNotEmpty()) {
+                    {
+                        TriStateCheckBox(
+                            state = parentState ?: ToggleableState.Off,
+                            enabled = enabled,
+                            onClick = {
+                                val descendantLeafIds = node.descendantLeafIds()
+                                val shouldCheck = parentState == ToggleableState.Off
+                                if (shouldCheck) {
+                                    checkedLeafIds += descendantLeafIds
+                                } else {
+                                    checkedLeafIds -= descendantLeafIds.toSet()
+                                }
+                            },
+                        )
+                    }
+                } else {
+                    {
+                        CheckBox(
+                            checked = node.id in checkedLeafIds,
+                            enabled = enabled,
+                            onCheckStateChange = { checked ->
+                                if (checked) {
+                                    checkedLeafIds += node.id
+                                } else {
+                                    checkedLeafIds -= node.id
+                                }
+                            },
+                        )
+                    }
+                }
+            } else {
+                null
+            }
+            val selected = if (showCheckbox) {
+                if (node.children.isNotEmpty()) {
+                    parentState == ToggleableState.On
+                } else {
+                    node.id in checkedLeafIds
+                }
+            } else {
+                selectedId == node.id
+            }
+            val itemOnClick: () -> Unit = if (showCheckbox) {
+                {}
+            } else {
+                {
+                    selectedId = if (selectedId == node.id) null else node.id
+                }
+            }
+            if (node.children.isNotEmpty()) {
+                TreeViewItem(
+                    selected = selected,
+                    onClick = itemOnClick,
+                    expanded = node.id in expandedIds,
+                    onExpandedChanged = { expanded ->
+                        if (expanded) expandedIds += node.id else expandedIds -= node.id
+                    },
+                    level = level,
+                    enabled = enabled,
+                    checkbox = checkboxContent,
+                    icon = iconContent,
+                    text = { Text(text = node.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                    modifier = Modifier.fillMaxWidth().animateItem(),
+                )
+            } else {
+                TreeViewItem(
+                    selected = selected,
+                    onClick = itemOnClick,
+                    level = level,
+                    enabled = enabled,
+                    checkbox = checkboxContent,
+                    icon = iconContent,
+                    text = { Text(text = node.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                    modifier = Modifier.fillMaxWidth().animateItem(),
+                )
+            }
+        }
+    }
+}
+
+private val TreeViewListMaxWidth = 380.dp


### PR DESCRIPTION
## Summary

- Add compact `TreeViewItem` overloads for leaf and expandable items.
- Support 16.dp hierarchy indentation, optional icons, standard selection indicators, and caller-owned checkbox slots.
- Animate checkbox-slot enter/exit and the horizontal content shift while preserving caller-owned checkbox state.
- Add standard, checkbox, and options Gallery samples backed by one shared nested `TreeNode` dataset.
- Register only visible tree rows through lazy intervals and animate item placement/removal without rebuilding the tree data.

https://github.com/user-attachments/assets/2ddd1695-3632-4d01-bb9c-e186c42c485e

## Behavior

- A supplied checkbox slot replaces the standard selection indicator.
- Checkbox mode maps `selected` to checkbox state; indeterminate parent nodes remain unselected.
- Sample row clicks remain enabled no-ops when a checkbox is supplied.
- Expandable items expose a dedicated click region from the level/checkbox boundary to the icon or text boundary.
- Expansion interactions share the row interaction source, and click bounds plus collapsed chevrons respect RTL layout.
- The options sample exposes checkbox, icon, and enabled states.
- Every sample row uses `animateItem()` for expansion and collapse changes.

## Review fixes

- Correct the expansion overlay's logical end padding from the measured physical content edge in both LTR and RTL.
- Mirror collapsed chevrons in RTL while keeping the expanded direction downward.
- Avoid registering hidden zero-height LazyColumn items; contiguous collapsed siblings stay in a single lazy interval, and recursion follows only visible expanded branches.

## Validation

- `./gradlew :fluent:compileCommonMainKotlinMetadata :gallery:sharedApp:compileCommonMainKotlinMetadata`
- `git diff --check`
- Final read-only source review: no Critical, Important, or Minor findings.

Gradle/build-script changes in the local checkout are intentionally excluded from this PR.