### PR TITLE
feat: add TeachingTip component

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/Flyout.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/Flyout.kt
@@ -232,6 +232,9 @@ internal fun BasicFlyout(
     onPreviewKeyEvent: ((keyEvent: KeyEvent) -> Boolean)? = null,
     focusable: Boolean = true,
     elevation: Dp = ElevationDefaults.flyout,
+    color: Color = FluentTheme.colors.background.acrylic.default,
+    strokeColor: Color = FluentTheme.colors.stroke.surface.flyout,
+    useAcrylic: Boolean = LocalAcrylicPopupEnabled.current,
     content: @Composable () -> Unit
 ) {
     val visibleState = remember {
@@ -259,7 +262,10 @@ internal fun BasicFlyout(
                     contentPadding = contentPadding,
                     enterPlacementAnimation = enterPlacementAnimation,
                     exitTransition = exitTransition,
-                    elevation = elevation
+                    elevation = elevation,
+                    color = color,
+                    strokeColor = strokeColor,
+                    useAcrylic = useAcrylic,
                 )
             } else {
                 /* this is the workaround for placement animation */
@@ -285,6 +291,9 @@ internal fun FlyoutContent(
     shape: Shape = FluentTheme.shapes.overlay,
     contentPadding: PaddingValues = PaddingValues(12.dp),
     elevation: Dp = ElevationDefaults.flyout,
+    color: Color = FluentTheme.colors.background.acrylic.default,
+    strokeColor: Color = FluentTheme.colors.stroke.surface.flyout,
+    useAcrylic: Boolean = LocalAcrylicPopupEnabled.current,
     content: @Composable () -> Unit
 ) {
     AcrylicPopupContent(
@@ -295,6 +304,9 @@ internal fun FlyoutContent(
         contentPadding = contentPadding,
         elevation = elevation,
         shape = shape,
+        color = color,
+        strokeColor = strokeColor,
+        useAcrylic = useAcrylic,
         modifier = modifier
     )
 }
@@ -309,10 +321,12 @@ internal fun AcrylicPopupContent(
     elevation: Dp,
     shape: Shape,
     contentPadding: PaddingValues,
+    color: Color = FluentTheme.colors.background.acrylic.default,
+    strokeColor: Color = FluentTheme.colors.stroke.surface.flyout,
+    useAcrylic: Boolean = LocalAcrylicPopupEnabled.current,
     content: @Composable () -> Unit
 ) {
     with(LocalWindowAcrylicContainer.current) {
-        val useAcrylic = LocalAcrylicPopupEnabled.current
         AnimatedVisibility(
             visibleState = visibleState,
             enter = enterTransition,
@@ -327,19 +341,20 @@ internal fun AcrylicPopupContent(
         ) {
             Layer(
                 backgroundSizing = BackgroundSizing.InnerBorderEdge,
-                border = BorderStroke(1.dp, FluentTheme.colors.stroke.surface.flyout),
+                border = BorderStroke(1.dp, strokeColor),
                 shape = shape,
                 elevation = elevation,
                 color = if (useAcrylic) {
                     Color.Transparent
                 } else {
-                    FluentTheme.colors.background.acrylic.default
+                    color
                 },
                 modifier = modifier
             ) {
                 FlyoutContentLayout(
                     contentPadding = contentPadding,
                     material = MaterialDefaults.acrylicDefault(),
+                    useAcrylic = useAcrylic,
                     shape = shape,
                     content = content
                 )
@@ -355,6 +370,7 @@ internal fun MaterialContainerScope.FlyoutContentLayout(
     material: Material,
     shape: Shape,
     contentPadding: PaddingValues,
+    useAcrylic: Boolean = LocalAcrylicPopupEnabled.current,
     content: @Composable () -> Unit
 ) {
     Layout(
@@ -377,7 +393,7 @@ internal fun MaterialContainerScope.FlyoutContentLayout(
                     .layoutId("placeholder")
                     .padding(1.dp)
                     .clip(acrylicShape)
-                    .materialOverlay(material = material)
+                    .materialOverlay(material = material, enabled = { useAcrylic })
             )
             Box(modifier = Modifier.padding(contentPadding).layoutId("content")) { content() }
         }

--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/NavigationView.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/NavigationView.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import io.github.composefluent.ExperimentalFluentApi
 import io.github.composefluent.FluentTheme
+import io.github.composefluent.LocalAcrylicPopupEnabled
 import io.github.composefluent.animation.FluentDuration
 import io.github.composefluent.animation.FluentEasing
 import io.github.composefluent.background.BackgroundSizing
@@ -458,10 +459,11 @@ private fun LeftCollapsedLayout(
                 )
             )
         ) {
+            val useAcrylic = LocalAcrylicPopupEnabled.current
             Layer(
                 backgroundSizing = BackgroundSizing.InnerBorderEdge,
                 border = BorderStroke(1.dp, FluentTheme.colors.stroke.surface.flyout),
-                color = Color.Transparent,
+                color = if (useAcrylic) Color.Transparent else FluentTheme.colors.background.acrylic.default,
                 shape = FluentTheme.shapes.overlay,
                 elevation = expandedTransition.animateDp(
                     targetValueByState = { if (it) ElevationDefaults.flyout else 0.dp },
@@ -610,6 +612,7 @@ private fun LeftCompactLayout(
                 !expandedTransition.currentState && !expandedTransition.isRunning
             }
         }
+        val useAcrylic = LocalAcrylicPopupEnabled.current
         Layer(
             backgroundSizing = BackgroundSizing.InnerBorderEdge,
             border = if (isCollapsed) {
@@ -617,7 +620,7 @@ private fun LeftCompactLayout(
             } else {
                 BorderStroke(1.dp, FluentTheme.colors.stroke.surface.flyout)
             },
-            color = Color.Transparent,
+            color = if (useAcrylic || (!expandedTransition.currentState && !expandedTransition.isRunning)) Color.Transparent else FluentTheme.colors.background.acrylic.default,
             shape = FluentTheme.shapes.overlay,
             elevation = expandedTransition.animateDp(
                 transitionSpec = {

--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/TeachingTip.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/TeachingTip.kt
@@ -1,0 +1,767 @@
+package io.github.composefluent.component
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.constrainHeight
+import androidx.compose.ui.unit.constrainWidth
+import androidx.compose.ui.unit.dp
+import io.github.composefluent.FluentTheme
+import io.github.composefluent.LocalTextStyle
+import io.github.composefluent.icons.Icons
+import io.github.composefluent.icons.regular.Dismiss
+import kotlin.math.min
+
+/**
+ * Displays a teaching tip centered in the window or pointing to [target].
+ *
+ * A non-null [target] adds a tail whose tip is placed on the teaching tip edge nearest the target.
+ * [placement] is treated as a preference: when that placement does not fit in the window, the
+ * teaching tip selects an available placement automatically. When [target] is `null`, the teaching
+ * tip has no tail and is centered in the window. Its content width is constrained to 320.dp.
+ *
+ * [target] uses window coordinates in physical pixels, matching the value returned by
+ * `LayoutCoordinates.boundsInWindow()`. Use [TeachingTipContainer] when a composable's complete
+ * bounds should be the target instead.
+ *
+ * The optional bottom action area contains at most two equal-width slots and fills them from the
+ * end. When both actions are present, [secondaryAction] occupies the start slot and [action]
+ * occupies the end slot.
+ *
+ * @param visible Whether the teaching tip is visible. This overload does not update this value.
+ * @param onDismissRequest Called when the teaching tip requests dismissal. The callback should
+ * update the state backing [visible].
+ * @param title The title shown at the top of the non-hero area. Its default text style is
+ * `bodyStrong` from [FluentTheme.typography].
+ * @param modifier The modifier applied to the teaching tip surface.
+ * @param icon Optional icon shown at the start of the title and content column. The recommended
+ * size is [TeachingTipDefaults.IconSize].
+ * @param target Optional target bounds in physical-pixel window coordinates.
+ * @param placement The preferred placement relative to [target]. Ignored when [target] is `null`.
+ * @param hero Optional hero content. It is placed on the side farthest from the resolved tail, or
+ * above the body when [target] is `null`.
+ * @param action Optional primary action shown in the end slot of the bottom action area.
+ * @param secondaryAction Optional secondary action. It occupies the start slot when [action] is
+ * also present; a single supplied action always occupies the end slot.
+ * @param closeAction Optional close action shown at the top end of the non-hero area.
+ * @param focusable Whether the teaching tip receives focus and can dismiss on outside interaction.
+ * @param content The main teaching tip content. Its default text style is `body` from
+ * [FluentTheme.typography].
+ */
+@Composable
+fun TeachingTip(
+    visible: Boolean,
+    onDismissRequest: () -> Unit,
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+    target: Rect? = null,
+    placement: FlyoutPlacement = FlyoutPlacement.Auto,
+    hero: (@Composable () -> Unit)? = null,
+    action: (@Composable () -> Unit)? = null,
+    secondaryAction: (@Composable () -> Unit)? = null,
+    closeAction: (@Composable () -> Unit)? = null,
+    focusable: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    TeachingTipPopup(
+        visible = visible,
+        onDismissRequest = onDismissRequest,
+        title = title,
+        content = content,
+        modifier = modifier,
+        icon = icon,
+        target = target,
+        usesContainerTarget = false,
+        placement = placement,
+        hero = hero,
+        action = action,
+        secondaryAction = secondaryAction,
+        closeAction = closeAction,
+        focusable = focusable,
+    )
+}
+
+/**
+ * Hosts a teaching tip whose target is the measured bounds of [content].
+ *
+ * Both [teachingTip] and [content] receive the same [TeachingTipContainerScope]. Its
+ * [TeachingTipContainerScope.isTeachingTipVisible] state starts as `false` and can be used by the
+ * anchor content, actions, and close button without an external state holder. The scoped
+ * [TeachingTipContainerScope.TeachingTip] function automatically uses the container bounds as its
+ * target.
+ *
+ * @param teachingTip The teaching tip to display for this container. Call the scoped
+ * [TeachingTipContainerScope.TeachingTip] function to target the container.
+ * @param modifier The modifier applied to the container that defines the target bounds.
+ * @param content The anchor content whose measured bounds are used as the teaching tip target.
+ */
+@Composable
+fun TeachingTipContainer(
+    teachingTip: @Composable TeachingTipContainerScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable TeachingTipContainerScope.() -> Unit,
+) {
+    val visibleState = remember { mutableStateOf(false) }
+    val scope = remember(visibleState) { TeachingTipContainerScopeImpl(visibleState) }
+    Box(modifier = modifier) {
+        scope.content()
+        scope.teachingTip()
+    }
+}
+
+/**
+ * Scope shared by a [TeachingTipContainer]'s anchor content and teaching tip.
+ *
+ * The scope owns the container's visibility state and provides a [TeachingTip] overload that uses
+ * the container bounds as its target.
+ */
+@Stable
+interface TeachingTipContainerScope {
+
+    /**
+     * Whether the container's teaching tip is visible.
+     *
+     * The initial value is `false`. The scoped [TeachingTip] uses this value by default and resets
+     * it to `false` when dismissal is requested.
+     */
+    var isTeachingTipVisible: Boolean
+
+    /**
+     * Displays a teaching tip targeted at this container's measured content bounds.
+     *
+     * [visible] and [onDismissRequest] use [isTeachingTipVisible] by default. When [visible] is
+     * backed by different state, provide a matching [onDismissRequest] that updates that state.
+     *
+     * @param title The title shown at the top of the non-hero area. Its default text style is
+     * `bodyStrong` from [FluentTheme.typography].
+     * @param modifier The modifier applied to the teaching tip surface.
+     * @param visible Whether the teaching tip is visible. Defaults to [isTeachingTipVisible].
+     * @param onDismissRequest Called when the teaching tip requests dismissal. By default it sets
+     * [isTeachingTipVisible] to `false`.
+     * @param icon Optional icon shown at the start of the title and content column. The recommended
+     * size is [TeachingTipDefaults.IconSize].
+     * @param placement The preferred placement relative to the container target. If it does not fit,
+     * an available placement is selected automatically.
+     * @param hero Optional hero content placed on the side farthest from the resolved tail.
+     * @param action Optional primary action shown in the end slot of the bottom action area.
+     * @param secondaryAction Optional secondary action. It occupies the start slot when [action] is
+     * also present; a single supplied action always occupies the end slot.
+     * @param closeAction Optional close action shown at the top end of the non-hero area.
+     * @param focusable Whether the teaching tip receives focus and can dismiss on outside interaction.
+     * @param content The main teaching tip content. Its default text style is `body` from
+     * [FluentTheme.typography].
+     */
+    @Composable
+    fun TeachingTip(
+        title: @Composable () -> Unit,
+        modifier: Modifier = Modifier,
+        visible: Boolean = isTeachingTipVisible,
+        onDismissRequest: () -> Unit = { isTeachingTipVisible = false },
+        icon: (@Composable () -> Unit)? = null,
+        placement: FlyoutPlacement = FlyoutPlacement.Auto,
+        hero: (@Composable () -> Unit)? = null,
+        action: (@Composable () -> Unit)? = null,
+        secondaryAction: (@Composable () -> Unit)? = null,
+        closeAction: (@Composable () -> Unit)? = null,
+        focusable: Boolean = true,
+        content: @Composable () -> Unit,
+    ) {
+        TeachingTipPopup(
+            visible = visible,
+            onDismissRequest = onDismissRequest,
+            title = title,
+            content = content,
+            modifier = modifier,
+            icon = icon,
+            target = null,
+            usesContainerTarget = true,
+            placement = placement,
+            hero = hero,
+            action = action,
+            secondaryAction = secondaryAction,
+            closeAction = closeAction,
+            focusable = focusable,
+        )
+    }
+}
+
+private class TeachingTipContainerScopeImpl(
+    visibleState: MutableState<Boolean>,
+) : TeachingTipContainerScope {
+    override var isTeachingTipVisible: Boolean by visibleState
+}
+
+/** Contains standard dimensions and building blocks for [TeachingTip]. */
+object TeachingTipDefaults {
+    internal val TailLength = 8.dp
+    internal val TailWidth = 14.6.dp
+    internal val WindowMargin = 8.dp
+
+    /** The recommended size for content supplied to a teaching tip's icon slot. */
+    val IconSize: Dp = 24.dp
+
+    /**
+     * Displays the standard icon-only close button for a teaching tip.
+     *
+     * @param onClick Called when the button is clicked.
+     * @param modifier The modifier applied to the button.
+     * @param enabled Whether the button responds to user interaction.
+     * @param contentDescription An accessibility description for the dismiss icon. Provide a
+     * localized description when the button is exposed to accessibility services.
+     */
+    @Composable
+    fun CloseButton(
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        enabled: Boolean = true,
+        contentDescription: String? = null,
+    ) {
+        SubtleButton(
+            onClick = onClick,
+            modifier = modifier.defaultMinSize(32.dp, 32.dp),
+            disabled = !enabled,
+            iconOnly = true,
+        ) {
+            Icon(Icons.Default.Dismiss, contentDescription = contentDescription)
+        }
+    }
+}
+
+@Composable
+private fun TeachingTipPopup(
+    visible: Boolean,
+    onDismissRequest: () -> Unit,
+    title: @Composable () -> Unit,
+    content: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)?,
+    target: Rect?,
+    usesContainerTarget: Boolean,
+    placement: FlyoutPlacement,
+    hero: (@Composable () -> Unit)?,
+    action: (@Composable () -> Unit)?,
+    secondaryAction: (@Composable () -> Unit)?,
+    closeAction: (@Composable () -> Unit)?,
+    focusable: Boolean,
+) {
+    val targeted = target != null || usesContainerTarget
+    val cornerRadius = FluentTheme.cornerRadius.overlay
+    val positionProvider = rememberTeachingTipPositionProvider(
+        visible = visible,
+        target = target,
+        usesContainerTarget = usesContainerTarget,
+        preferredPlacement = placement,
+        cornerRadius = cornerRadius,
+    )
+    val shape = TeachingTipShape(
+        cornerRadius = cornerRadius,
+        tailEdge = positionProvider.tailEdge,
+        tailOffsetFraction = positionProvider.tailOffsetFraction,
+    )
+    val tailPadding = if (targeted) TeachingTipDefaults.TailLength else 0.dp
+
+    BasicFlyout(
+        visible = visible,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        enterPlacementAnimation = { teachingTipEnterTransition(positionProvider.transformOrigin) },
+        exitTransition = teachingTipExitTransition(positionProvider.transformOrigin),
+        shape = shape,
+        contentPadding = PaddingValues(tailPadding + TeachingTipDefaults.BorderPadding),
+        positionProvider = positionProvider,
+        focusable = focusable,
+        color = FluentTheme.colors.background.solid.tertiary,
+        strokeColor = FluentTheme.colors.stroke.surface.default,
+        useAcrylic = false,
+    ) {
+        TeachingTipLayout(
+            tailEdge = positionProvider.tailEdge,
+            targeted = targeted,
+            placement = placement,
+            title = title,
+            content = content,
+            icon = icon,
+            hero = hero,
+            action = action,
+            secondaryAction = secondaryAction,
+            closeAction = closeAction,
+        )
+    }
+}
+
+@Composable
+private fun TeachingTipLayout(
+    tailEdge: TeachingTipTailEdge,
+    targeted: Boolean,
+    placement: FlyoutPlacement,
+    title: @Composable () -> Unit,
+    content: @Composable () -> Unit,
+    icon: (@Composable () -> Unit)?,
+    hero: (@Composable () -> Unit)?,
+    action: (@Composable () -> Unit)?,
+    secondaryAction: (@Composable () -> Unit)?,
+    closeAction: (@Composable () -> Unit)?,
+) {
+    val layoutDirection = LocalLayoutDirection.current
+    val body = @Composable {
+        TeachingTipBody(
+            title = title,
+            content = content,
+            icon = icon,
+            action = action,
+            secondaryAction = secondaryAction,
+            closeAction = closeAction,
+        )
+    }
+    val heroEdge = when {
+        !targeted -> TeachingTipTailEdge.Top
+        tailEdge != TeachingTipTailEdge.None -> tailEdge.opposite()
+        else -> placement.initialTeachingTipTailEdge(layoutDirection).opposite()
+    }
+    // Keep the tip at its standard width while allowing narrow windows to shrink it.
+    // widthIn must wrap fillMaxWidth so the fill operation sees the capped constraints.
+    val widthModifier = Modifier
+        .widthIn(max = TeachingTipDefaults.BodyWidth)
+        .fillMaxWidth()
+
+    when {
+        hero == null -> Box(widthModifier) { body() }
+        heroEdge == TeachingTipTailEdge.Top -> Column(widthModifier) {
+            TeachingTipHero(hero)
+            body()
+        }
+
+        heroEdge == TeachingTipTailEdge.Bottom -> Column(widthModifier) {
+            body()
+            TeachingTipHero(hero)
+        }
+
+        heroEdge == TeachingTipTailEdge.Left -> TeachingTipHorizontalHero(
+            heroOnLeft = true,
+            hero = hero,
+            body = body,
+        )
+
+        else -> TeachingTipHorizontalHero(
+            heroOnLeft = false,
+            hero = hero,
+            body = body,
+        )
+    }
+}
+
+@Composable
+private fun TeachingTipHorizontalHero(
+    heroOnLeft: Boolean,
+    hero: @Composable () -> Unit,
+    body: @Composable () -> Unit,
+) {
+    Layout(
+        modifier = Modifier
+            .widthIn(max = TeachingTipDefaults.HorizontalHeroWidth)
+            .fillMaxWidth(),
+        content = {
+            Box(
+                modifier = Modifier.layoutId(TeachingTipHeroLayoutId),
+                propagateMinConstraints = true,
+            ) {
+                hero()
+            }
+            Box(
+                modifier = Modifier.layoutId(TeachingTipBodyLayoutId),
+                propagateMinConstraints = true,
+            ) {
+                body()
+            }
+        },
+    ) { measurables, constraints ->
+        val totalWidth = constraints.constrainWidth(TeachingTipDefaults.HorizontalHeroWidth.roundToPx())
+        val heroWidth = TeachingTipDefaults.SideHeroWidth.roundToPx().coerceAtMost(totalWidth)
+        val bodyWidth = (totalWidth - heroWidth).coerceAtLeast(0)
+        val bodyPlaceable = measurables.first { it.layoutId == TeachingTipBodyLayoutId }.measure(
+            constraints.copy(
+                minWidth = bodyWidth,
+                maxWidth = bodyWidth,
+                minHeight = 0,
+            )
+        )
+        val height = constraints.constrainHeight(bodyPlaceable.height)
+        val heroPlaceable = measurables.first { it.layoutId == TeachingTipHeroLayoutId }.measure(
+            Constraints.fixed(heroWidth, height)
+        )
+        layout(totalWidth, height) {
+            if (heroOnLeft) {
+                heroPlaceable.place(0, 0)
+                bodyPlaceable.place(heroWidth, 0)
+            } else {
+                bodyPlaceable.place(0, 0)
+                heroPlaceable.place(bodyWidth, 0)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TeachingTipHero(hero: @Composable () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        propagateMinConstraints = true,
+    ) {
+        hero()
+    }
+}
+
+@Composable
+private fun TeachingTipBody(
+    title: @Composable () -> Unit,
+    content: @Composable () -> Unit,
+    icon: (@Composable () -> Unit)?,
+    action: (@Composable () -> Unit)?,
+    secondaryAction: (@Composable () -> Unit)?,
+    closeAction: (@Composable () -> Unit)?,
+) {
+    val hasActions = action != null || secondaryAction != null
+    val titleTextStyle = FluentTheme.typography.bodyStrong.withUntrimmedLineHeight()
+    val contentTextStyle = FluentTheme.typography.body.withUntrimmedLineHeight()
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        val hasCloseAction = closeAction != null
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (icon != null) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    icon()
+                }
+            }
+            Column(Modifier.weight(1f)) {
+                CompositionLocalProvider(LocalTextStyle provides titleTextStyle) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                start = if (icon == null) {
+                                    TeachingTipDefaults.TitleHorizontalPadding
+                                } else {
+                                    0.dp
+                                },
+                                top = TeachingTipDefaults.TitleTopPadding,
+                                end = if (!hasCloseAction) TeachingTipDefaults.TitleHorizontalPadding else 0.dp,
+                            ),
+                    ) {
+                        title()
+                    }
+                }
+
+                CompositionLocalProvider(LocalTextStyle provides contentTextStyle) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                start = if (icon == null) {
+                                    TeachingTipDefaults.ContentHorizontalPadding
+                                } else {
+                                    0.dp
+                                },
+                                end = if (!hasCloseAction) TeachingTipDefaults.ContentHorizontalPadding else 0.dp,
+                                bottom = TeachingTipDefaults.ContentBottomPadding,
+                            ),
+                    ) {
+                        content()
+                    }
+                }
+            }
+            if (hasCloseAction) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .align(Alignment.Top)
+                        .size(40.dp),
+                ) {
+                    closeAction()
+                }
+            }
+        }
+        if (hasActions) {
+            TeachingTipActionRow(
+                action = action,
+                secondaryAction = secondaryAction,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TeachingTipActionRow(
+    action: (@Composable () -> Unit)?,
+    secondaryAction: (@Composable () -> Unit)?,
+) {
+    val actions = listOfNotNull(secondaryAction, action)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                start = TeachingTipDefaults.ActionHorizontalPadding,
+                top = TeachingTipDefaults.ActionTopPadding,
+                end = TeachingTipDefaults.ActionHorizontalPadding,
+                bottom = TeachingTipDefaults.ActionBottomPadding,
+            ),
+        horizontalArrangement = Arrangement.spacedBy(TeachingTipDefaults.ActionSpacing),
+    ) {
+        repeat(2 - actions.size) {
+            Spacer(Modifier.weight(1f))
+        }
+        actions.forEach { actionContent ->
+            Box(
+                modifier = Modifier.weight(1f),
+                propagateMinConstraints = true,
+            ) {
+                actionContent()
+            }
+        }
+    }
+}
+
+@Immutable
+private class TeachingTipShape(
+    private val cornerRadius: Dp,
+    private val tailEdge: TeachingTipTailEdge,
+    private val tailOffsetFraction: Float,
+) : Shape {
+
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Outline = with(density) {
+        val tailLength = if (tailEdge == TeachingTipTailEdge.None) {
+            0f
+        } else {
+            TeachingTipDefaults.TailLength.toPx()
+        }
+        val tailHalfWidth = TeachingTipDefaults.TailWidth.toPx() / 2f
+        val left = tailLength
+        val top = tailLength
+        val right = size.width - tailLength
+        val bottom = size.height - tailLength
+        val radius = min(
+            cornerRadius.toPx(),
+            min((right - left).coerceAtLeast(0f), (bottom - top).coerceAtLeast(0f)) / 2f,
+        )
+
+        if (tailEdge == TeachingTipTailEdge.None) {
+            return@with Outline.Rounded(
+                RoundRect(
+                    left = 0f,
+                    top = 0f,
+                    right = size.width,
+                    bottom = size.height,
+                    cornerRadius = CornerRadius(radius, radius),
+                )
+            )
+        }
+
+        val horizontalTail = constrainTailCenter(
+            value = left + (right - left) * tailOffsetFraction,
+            min = left + radius + tailHalfWidth,
+            max = right - radius - tailHalfWidth,
+        )
+        val verticalTail = constrainTailCenter(
+            value = top + (bottom - top) * tailOffsetFraction,
+            min = top + radius + tailHalfWidth,
+            max = bottom - radius - tailHalfWidth,
+        )
+        val curve = radius * CornerCurveControl
+        Outline.Generic(Path().apply {
+            moveTo(left + radius, top)
+            if (tailEdge == TeachingTipTailEdge.Top) {
+                lineTo(horizontalTail - tailHalfWidth, top)
+                lineTo(horizontalTail, 0f)
+                lineTo(horizontalTail + tailHalfWidth, top)
+            }
+            lineTo(right - radius, top)
+            cubicTo(right - radius + curve, top, right, top + radius - curve, right, top + radius)
+
+            if (tailEdge == TeachingTipTailEdge.Right) {
+                lineTo(right, verticalTail - tailHalfWidth)
+                lineTo(size.width, verticalTail)
+                lineTo(right, verticalTail + tailHalfWidth)
+            }
+            lineTo(right, bottom - radius)
+            cubicTo(right, bottom - radius + curve, right - radius + curve, bottom, right - radius, bottom)
+
+            if (tailEdge == TeachingTipTailEdge.Bottom) {
+                lineTo(horizontalTail + tailHalfWidth, bottom)
+                lineTo(horizontalTail, size.height)
+                lineTo(horizontalTail - tailHalfWidth, bottom)
+            }
+            lineTo(left + radius, bottom)
+            cubicTo(left + radius - curve, bottom, left, bottom - radius + curve, left, bottom - radius)
+
+            if (tailEdge == TeachingTipTailEdge.Left) {
+                lineTo(left, verticalTail + tailHalfWidth)
+                lineTo(0f, verticalTail)
+                lineTo(left, verticalTail - tailHalfWidth)
+            }
+            lineTo(left, top + radius)
+            cubicTo(left, top + radius - curve, left + radius - curve, top, left + radius, top)
+            close()
+        })
+    }
+}
+
+private fun constrainTailCenter(value: Float, min: Float, max: Float): Float {
+    return if (max >= min) value.coerceIn(min, max) else (min + max) / 2f
+}
+
+private fun teachingTipEnterTransition(transformOrigin: TransformOrigin): EnterTransition {
+    return scaleIn(
+        animationSpec = flyoutEnterSpec(),
+        initialScale = 0f,
+        transformOrigin = transformOrigin,
+    )
+}
+
+private fun teachingTipExitTransition(transformOrigin: TransformOrigin): ExitTransition {
+    return scaleOut(
+        animationSpec = flyoutExitSpec(),
+        targetScale = 0f,
+        transformOrigin = transformOrigin,
+    )
+}
+
+private val TeachingTipDefaults.BodyWidth: Dp
+    get() = 320.dp
+
+private val TeachingTipDefaults.HorizontalHeroWidth: Dp
+    get() = BodyWidth
+
+private val TeachingTipDefaults.SideHeroWidth: Dp
+    get() = 96.dp
+
+private val TeachingTipDefaults.TitleHorizontalPadding: Dp
+    get() = 12.dp
+
+private val TeachingTipDefaults.TitleTopPadding: Dp
+    get() = 9.dp
+
+private val TeachingTipDefaults.ContentHorizontalPadding: Dp
+    get() = 12.dp
+
+private val TeachingTipDefaults.ContentBottomPadding: Dp
+    get() = 11.dp
+
+private val TeachingTipDefaults.IconHorizontalPadding: Dp
+    get() = 16.dp
+
+private val TeachingTipDefaults.BorderPadding: Dp
+    get() = 1.dp
+
+private val TeachingTipDefaults.ActionTopPadding: Dp
+    get() = 2.dp
+
+private val TeachingTipDefaults.ActionHorizontalPadding: Dp
+    get() = 12.dp
+
+private val TeachingTipDefaults.ActionBottomPadding: Dp
+    get() = 12.dp
+
+private val TeachingTipDefaults.ActionSpacing: Dp
+    get() = 8.dp
+
+private const val CornerCurveControl = 0.5522848f
+private const val TeachingTipHeroLayoutId = "hero"
+private const val TeachingTipBodyLayoutId = "body"
+
+private fun TextStyle.withUntrimmedLineHeight(): TextStyle {
+    val currentLineHeightStyle = lineHeightStyle ?: LineHeightStyle.Default
+    return copy(
+        lineHeightStyle = currentLineHeightStyle.copy(trim = LineHeightStyle.Trim.None),
+    )
+}
+
+private fun FlyoutPlacement.initialTeachingTipTailEdge(
+    layoutDirection: LayoutDirection,
+): TeachingTipTailEdge {
+    return when (this) {
+        FlyoutPlacement.Top,
+        FlyoutPlacement.TopAlignedStart,
+        FlyoutPlacement.TopAlignedEnd,
+        FlyoutPlacement.Auto -> TeachingTipTailEdge.Bottom
+
+        FlyoutPlacement.Bottom,
+        FlyoutPlacement.BottomAlignedStart,
+        FlyoutPlacement.BottomAlignedEnd -> TeachingTipTailEdge.Top
+
+        FlyoutPlacement.Start,
+        FlyoutPlacement.StartAlignedTop,
+        FlyoutPlacement.StartAlignedBottom -> {
+            if (layoutDirection == LayoutDirection.Ltr) TeachingTipTailEdge.Right else TeachingTipTailEdge.Left
+        }
+
+        FlyoutPlacement.End,
+        FlyoutPlacement.EndAlignedTop,
+        FlyoutPlacement.EndAlignedBottom -> {
+            if (layoutDirection == LayoutDirection.Ltr) TeachingTipTailEdge.Left else TeachingTipTailEdge.Right
+        }
+
+        FlyoutPlacement.Full -> TeachingTipTailEdge.Top
+    }
+}
+
+private fun TeachingTipTailEdge.opposite(): TeachingTipTailEdge {
+    return when (this) {
+        TeachingTipTailEdge.None -> TeachingTipTailEdge.None
+        TeachingTipTailEdge.Top -> TeachingTipTailEdge.Bottom
+        TeachingTipTailEdge.Bottom -> TeachingTipTailEdge.Top
+        TeachingTipTailEdge.Left -> TeachingTipTailEdge.Right
+        TeachingTipTailEdge.Right -> TeachingTipTailEdge.Left
+    }
+}

--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/TeachingTipPositionProvider.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/TeachingTipPositionProvider.kt
@@ -1,0 +1,466 @@
+package io.github.composefluent.component
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun rememberTeachingTipPositionProvider(
+    visible: Boolean,
+    target: Rect?,
+    usesContainerTarget: Boolean,
+    preferredPlacement: FlyoutPlacement,
+    cornerRadius: Dp,
+): TeachingTipPositionProvider {
+    val density = LocalDensity.current
+    val positionProvider = remember(target, usesContainerTarget, preferredPlacement, cornerRadius, density) {
+        TeachingTipPositionProvider(
+            density = density,
+            target = target,
+            usesContainerTarget = usesContainerTarget,
+            preferredPlacement = preferredPlacement,
+            cornerRadius = cornerRadius,
+        )
+    }
+    SideEffect {
+        positionProvider.updateVisibility(visible)
+    }
+    return positionProvider
+}
+
+@Stable
+internal class TeachingTipPositionProvider(
+    private val density: Density,
+    private val target: Rect?,
+    private val usesContainerTarget: Boolean,
+    private val preferredPlacement: FlyoutPlacement,
+    private val cornerRadius: Dp,
+) : FlyoutPositionProvider(
+    density = density,
+    initialPlacement = preferredPlacement,
+    paddingToAnchor = PaddingValues(0.dp),
+    adaptivePlacement = true,
+) {
+
+    private var maximumPopupSize = IntSize.Zero
+    private var lastPopupSize = IntSize.Zero
+    private var lastMeasuredTailEdge = TeachingTipTailEdge.None
+    private var wasVisible = false
+
+    var tailEdge by mutableStateOf(TeachingTipTailEdge.None)
+        private set
+
+    var tailOffsetFraction by mutableStateOf(0.5f)
+        private set
+
+    var transformOrigin by mutableStateOf(TransformOrigin.Center)
+        private set
+
+    fun updateVisibility(visible: Boolean) {
+        if (visible != wasVisible) {
+            resetPopupSizeCache()
+            wasVisible = visible
+        }
+    }
+
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        applyAnimation = false
+
+        val targetBounds = target ?: if (usesContainerTarget) {
+            Rect(
+                left = anchorBounds.left.toFloat(),
+                top = anchorBounds.top.toFloat(),
+                right = anchorBounds.right.toFloat(),
+                bottom = anchorBounds.bottom.toFloat(),
+            )
+        } else {
+            null
+        }
+        if (targetBounds == null) {
+            targetPlacement = FlyoutPlacement.Full
+            tailEdge = TeachingTipTailEdge.None
+            tailOffsetFraction = 0.5f
+            transformOrigin = TransformOrigin.Center
+            applyAnimation = true
+            return IntOffset(
+                x = ((windowSize.width - popupContentSize.width) / 2).coerceAtLeast(0),
+                y = ((windowSize.height - popupContentSize.height) / 2).coerceAtLeast(0),
+            )
+        }
+
+        updatePopupSizeCache(popupContentSize)
+        val tailLengthPx = with(density) { TeachingTipDefaults.TailLength.toPx() }
+        val measuredBodySize = BodySize(
+            width = (maximumPopupSize.width - tailLengthPx * 2f).coerceAtLeast(0f),
+            height = (maximumPopupSize.height - tailLengthPx * 2f).coerceAtLeast(0f),
+        )
+        val actualBodySize = BodySize(
+            width = (popupContentSize.width - tailLengthPx * 2f).coerceAtLeast(0f),
+            height = (popupContentSize.height - tailLengthPx * 2f).coerceAtLeast(0f),
+        )
+        val candidates = placementOrder(preferredPlacement).map { placement ->
+            placementCandidate(
+                placement = placement,
+                targetBounds = targetBounds,
+                windowSize = windowSize,
+                layoutDirection = layoutDirection,
+                bodySize = measuredBodySize,
+                tailLength = tailLengthPx,
+            )
+        }
+        val windowMarginPx = with(density) { TeachingTipDefaults.WindowMargin.toPx() }
+        val selected = candidates.firstOrNull {
+            overflow(it.outerBounds, windowSize, windowMarginPx) == 0f
+        } ?: candidates.minBy { overflow(it.outerBounds, windowSize, windowMarginPx) }
+
+        val actualCandidate = placementCandidate(
+            placement = selected.placement,
+            targetBounds = targetBounds,
+            windowSize = windowSize,
+            layoutDirection = layoutDirection,
+            bodySize = actualBodySize,
+            tailLength = tailLengthPx,
+        )
+        val outerOffset = IntOffset(
+            x = constrainToWindow(
+                value = actualCandidate.outerBounds.left,
+                contentSize = popupContentSize.width.toFloat(),
+                windowSize = windowSize.width.toFloat(),
+                margin = windowMarginPx,
+            ).toInt(),
+            y = constrainToWindow(
+                value = actualCandidate.outerBounds.top,
+                contentSize = popupContentSize.height.toFloat(),
+                windowSize = windowSize.height.toFloat(),
+                margin = windowMarginPx,
+            ).toInt(),
+        )
+        val bodyBounds = Rect(
+            left = outerOffset.x + tailLengthPx,
+            top = outerOffset.y + tailLengthPx,
+            right = outerOffset.x + tailLengthPx + actualBodySize.width,
+            bottom = outerOffset.y + tailLengthPx + actualBodySize.height,
+        )
+        val tail = nearestTail(
+            bodyBounds = bodyBounds,
+            targetBounds = targetBounds,
+            preferredEdge = selected.placement.tailEdge(layoutDirection),
+            tailLength = tailLengthPx,
+            tailWidth = with(density) { TeachingTipDefaults.TailWidth.toPx() },
+            cornerRadius = with(density) { cornerRadius.toPx() },
+        )
+
+        targetPlacement = selected.placement
+        tailEdge = tail.edge
+        tailOffsetFraction = tail.offsetFraction
+        val tailVertexX = when (tail.edge) {
+            TeachingTipTailEdge.Top,
+            TeachingTipTailEdge.Bottom -> tailLengthPx + actualBodySize.width * tail.offsetFraction
+
+            TeachingTipTailEdge.Left -> 0f
+            TeachingTipTailEdge.Right -> popupContentSize.width.toFloat()
+            TeachingTipTailEdge.None -> popupContentSize.width / 2f
+        }
+        val tailVertexY = when (tail.edge) {
+            TeachingTipTailEdge.Top -> 0f
+            TeachingTipTailEdge.Bottom -> popupContentSize.height.toFloat()
+            TeachingTipTailEdge.Left,
+            TeachingTipTailEdge.Right -> tailLengthPx + actualBodySize.height * tail.offsetFraction
+
+            TeachingTipTailEdge.None -> popupContentSize.height / 2f
+        }
+        transformOrigin = TransformOrigin(
+            pivotFractionX = if (popupContentSize.width == 0) {
+                0.5f
+            } else {
+                tailVertexX / popupContentSize.width.toFloat()
+            },
+            pivotFractionY = if (popupContentSize.height == 0) {
+                0.5f
+            } else {
+                tailVertexY / popupContentSize.height.toFloat()
+            },
+        )
+        applyAnimation = true
+        return outerOffset
+    }
+
+    private fun updatePopupSizeCache(popupContentSize: IntSize) {
+        val tailEdgeChanged = tailEdge != lastMeasuredTailEdge
+        val popupSizeChanged = popupContentSize != lastPopupSize
+        maximumPopupSize = if (
+            maximumPopupSize == IntSize.Zero || (!tailEdgeChanged && popupSizeChanged)
+        ) {
+            popupContentSize
+        } else {
+            IntSize(
+                width = maxOf(maximumPopupSize.width, popupContentSize.width),
+                height = maxOf(maximumPopupSize.height, popupContentSize.height),
+            )
+        }
+        lastPopupSize = popupContentSize
+        lastMeasuredTailEdge = tailEdge
+    }
+
+    private fun resetPopupSizeCache() {
+        maximumPopupSize = IntSize.Zero
+        lastPopupSize = IntSize.Zero
+        lastMeasuredTailEdge = tailEdge
+    }
+
+    private fun placementCandidate(
+        placement: FlyoutPlacement,
+        targetBounds: Rect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        bodySize: BodySize,
+        tailLength: Float,
+    ): PlacementCandidate {
+        val targetCenter = targetBounds.center
+        val centeredX = targetCenter.x - bodySize.width / 2f
+        val centeredY = targetCenter.y - bodySize.height / 2f
+        val alignedStartX = if (layoutDirection == LayoutDirection.Ltr) {
+            targetBounds.left
+        } else {
+            targetBounds.right - bodySize.width
+        }
+        val alignedEndX = if (layoutDirection == LayoutDirection.Ltr) {
+            targetBounds.right - bodySize.width
+        } else {
+            targetBounds.left
+        }
+        val startX = if (layoutDirection == LayoutDirection.Ltr) {
+            targetBounds.left - tailLength - bodySize.width
+        } else {
+            targetBounds.right + tailLength
+        }
+        val endX = if (layoutDirection == LayoutDirection.Ltr) {
+            targetBounds.right + tailLength
+        } else {
+            targetBounds.left - tailLength - bodySize.width
+        }
+        val topY = targetBounds.top - tailLength - bodySize.height
+        val bottomY = targetBounds.bottom + tailLength
+
+        val bodyOffset = when (placement) {
+            FlyoutPlacement.Top -> Offset(centeredX, topY)
+            FlyoutPlacement.TopAlignedStart -> Offset(alignedStartX, topY)
+            FlyoutPlacement.TopAlignedEnd -> Offset(alignedEndX, topY)
+            FlyoutPlacement.Bottom -> Offset(centeredX, bottomY)
+            FlyoutPlacement.BottomAlignedStart -> Offset(alignedStartX, bottomY)
+            FlyoutPlacement.BottomAlignedEnd -> Offset(alignedEndX, bottomY)
+            FlyoutPlacement.Start -> Offset(startX, centeredY)
+            FlyoutPlacement.StartAlignedTop -> Offset(startX, targetBounds.top)
+            FlyoutPlacement.StartAlignedBottom -> Offset(startX, targetBounds.bottom - bodySize.height)
+            FlyoutPlacement.End -> Offset(endX, centeredY)
+            FlyoutPlacement.EndAlignedTop -> Offset(endX, targetBounds.top)
+            FlyoutPlacement.EndAlignedBottom -> Offset(endX, targetBounds.bottom - bodySize.height)
+            FlyoutPlacement.Full, FlyoutPlacement.Auto -> Offset(
+                x = (windowSize.width - bodySize.width) / 2f,
+                y = (windowSize.height - bodySize.height) / 2f,
+            )
+        }
+        return PlacementCandidate(
+            placement = placement,
+            outerBounds = Rect(
+                left = bodyOffset.x - tailLength,
+                top = bodyOffset.y - tailLength,
+                right = bodyOffset.x + bodySize.width + tailLength,
+                bottom = bodyOffset.y + bodySize.height + tailLength,
+            ),
+        )
+    }
+}
+
+internal enum class TeachingTipTailEdge {
+    None,
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+private data class BodySize(
+    val width: Float,
+    val height: Float,
+)
+
+private data class PlacementCandidate(
+    val placement: FlyoutPlacement,
+    val outerBounds: Rect,
+)
+
+private data class TeachingTipTail(
+    val edge: TeachingTipTailEdge,
+    val offsetFraction: Float,
+)
+
+private fun placementOrder(preferredPlacement: FlyoutPlacement): List<FlyoutPlacement> {
+    val top = listOf(
+        FlyoutPlacement.Top,
+        FlyoutPlacement.TopAlignedStart,
+        FlyoutPlacement.TopAlignedEnd,
+    )
+    val bottom = listOf(
+        FlyoutPlacement.Bottom,
+        FlyoutPlacement.BottomAlignedStart,
+        FlyoutPlacement.BottomAlignedEnd,
+    )
+    val start = listOf(
+        FlyoutPlacement.Start,
+        FlyoutPlacement.StartAlignedTop,
+        FlyoutPlacement.StartAlignedBottom,
+    )
+    val end = listOf(
+        FlyoutPlacement.End,
+        FlyoutPlacement.EndAlignedTop,
+        FlyoutPlacement.EndAlignedBottom,
+    )
+    val fallback = when (preferredPlacement) {
+        in top -> top + bottom + end + start
+        in bottom -> bottom + top + end + start
+        in start -> start + end + top + bottom
+        in end -> end + start + top + bottom
+        else -> top + bottom + end + start
+    } + FlyoutPlacement.Full
+    return if (preferredPlacement == FlyoutPlacement.Auto) {
+        fallback
+    } else {
+        listOf(preferredPlacement) + fallback.filterNot { it == preferredPlacement }
+    }
+}
+
+private fun overflow(bounds: Rect, windowSize: IntSize, margin: Float): Float {
+    val effectiveMarginX = margin.coerceAtMost(windowSize.width / 2f)
+    val effectiveMarginY = margin.coerceAtMost(windowSize.height / 2f)
+    return (effectiveMarginX - bounds.left).coerceAtLeast(0f) +
+            (effectiveMarginY - bounds.top).coerceAtLeast(0f) +
+            (bounds.right - windowSize.width + effectiveMarginX).coerceAtLeast(0f) +
+            (bounds.bottom - windowSize.height + effectiveMarginY).coerceAtLeast(0f)
+}
+
+private fun constrainToWindow(
+    value: Float,
+    contentSize: Float,
+    windowSize: Float,
+    margin: Float,
+): Float {
+    val effectiveMargin = margin.coerceAtMost(windowSize / 2f)
+    val max = windowSize - effectiveMargin - contentSize
+    return if (max >= effectiveMargin) {
+        value.coerceIn(effectiveMargin, max)
+    } else {
+        (windowSize - contentSize) / 2f
+    }
+}
+
+private fun nearestTail(
+    bodyBounds: Rect,
+    targetBounds: Rect,
+    preferredEdge: TeachingTipTailEdge,
+    tailLength: Float,
+    tailWidth: Float,
+    cornerRadius: Float,
+): TeachingTipTail {
+    val safeInset = cornerRadius + tailWidth / 2f
+    val targetCenter = targetBounds.center
+    val horizontalPosition = constrainTailPosition(
+        value = targetCenter.x,
+        min = bodyBounds.left + safeInset,
+        max = bodyBounds.right - safeInset,
+    )
+    val verticalPosition = constrainTailPosition(
+        value = targetCenter.y,
+        min = bodyBounds.top + safeInset,
+        max = bodyBounds.bottom - safeInset,
+    )
+    val points = mapOf(
+        TeachingTipTailEdge.Top to Offset(horizontalPosition, bodyBounds.top - tailLength),
+        TeachingTipTailEdge.Bottom to Offset(horizontalPosition, bodyBounds.bottom + tailLength),
+        TeachingTipTailEdge.Left to Offset(bodyBounds.left - tailLength, verticalPosition),
+        TeachingTipTailEdge.Right to Offset(bodyBounds.right + tailLength, verticalPosition),
+    )
+    val edgeOrder = listOf(preferredEdge) + points.keys.filterNot { it == preferredEdge }
+    val edge = edgeOrder.filter { it != TeachingTipTailEdge.None }.minBy { candidate ->
+        distanceSquared(points.getValue(candidate), targetBounds)
+    }
+    val point = points.getValue(edge)
+    val fraction = when (edge) {
+        TeachingTipTailEdge.Top, TeachingTipTailEdge.Bottom -> {
+            if (bodyBounds.width == 0f) 0.5f else (point.x - bodyBounds.left) / bodyBounds.width
+        }
+
+        TeachingTipTailEdge.Left, TeachingTipTailEdge.Right -> {
+            if (bodyBounds.height == 0f) 0.5f else (point.y - bodyBounds.top) / bodyBounds.height
+        }
+
+        TeachingTipTailEdge.None -> 0.5f
+    }
+    return TeachingTipTail(edge, fraction.coerceIn(0f, 1f))
+}
+
+private fun constrainTailPosition(value: Float, min: Float, max: Float): Float {
+    return if (max >= min) value.coerceIn(min, max) else (min + max) / 2f
+}
+
+private fun distanceSquared(point: Offset, bounds: Rect): Float {
+    val horizontalDistance = when {
+        point.x < bounds.left -> bounds.left - point.x
+        point.x > bounds.right -> point.x - bounds.right
+        else -> 0f
+    }
+    val verticalDistance = when {
+        point.y < bounds.top -> bounds.top - point.y
+        point.y > bounds.bottom -> point.y - bounds.bottom
+        else -> 0f
+    }
+    return horizontalDistance * horizontalDistance + verticalDistance * verticalDistance
+}
+
+private fun FlyoutPlacement.tailEdge(layoutDirection: LayoutDirection): TeachingTipTailEdge {
+    return when (this) {
+        FlyoutPlacement.Top,
+        FlyoutPlacement.TopAlignedStart,
+        FlyoutPlacement.TopAlignedEnd -> TeachingTipTailEdge.Bottom
+
+        FlyoutPlacement.Bottom,
+        FlyoutPlacement.BottomAlignedStart,
+        FlyoutPlacement.BottomAlignedEnd -> TeachingTipTailEdge.Top
+
+        FlyoutPlacement.Start,
+        FlyoutPlacement.StartAlignedTop,
+        FlyoutPlacement.StartAlignedBottom -> {
+            if (layoutDirection == LayoutDirection.Ltr) TeachingTipTailEdge.Right else TeachingTipTailEdge.Left
+        }
+
+        FlyoutPlacement.End,
+        FlyoutPlacement.EndAlignedTop,
+        FlyoutPlacement.EndAlignedBottom -> {
+            if (layoutDirection == LayoutDirection.Ltr) TeachingTipTailEdge.Left else TeachingTipTailEdge.Right
+        }
+
+        FlyoutPlacement.Auto,
+        FlyoutPlacement.Full -> TeachingTipTailEdge.None
+    }
+}

--- a/gallery/sharedApp/src/commonMain/kotlin/io/github/composefluent/gallery/screen/dialogs/TeachingTipScreen.kt
+++ b/gallery/sharedApp/src/commonMain/kotlin/io/github/composefluent/gallery/screen/dialogs/TeachingTipScreen.kt
@@ -1,0 +1,411 @@
+package io.github.composefluent.gallery.screen.dialogs
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.dp
+import io.github.composefluent.FluentTheme
+import io.github.composefluent.component.Button
+import io.github.composefluent.component.CheckBox
+import io.github.composefluent.component.FlyoutPlacement
+import io.github.composefluent.component.Icon
+import io.github.composefluent.component.TeachingTip
+import io.github.composefluent.component.TeachingTipContainer
+import io.github.composefluent.component.TeachingTipDefaults
+import io.github.composefluent.component.Text
+import io.github.composefluent.gallery.annotation.Component
+import io.github.composefluent.gallery.annotation.Sample
+import io.github.composefluent.gallery.component.ComponentPagePath
+import io.github.composefluent.gallery.component.GalleryPage
+import io.github.composefluent.gallery.resources.Res
+import io.github.composefluent.gallery.resources.banner
+import io.github.composefluent.icons.Icons
+import io.github.composefluent.icons.regular.Lightbulb
+import io.github.composefluent.source.generated.FluentSourceFile
+import org.jetbrains.compose.resources.painterResource
+
+@Component(index = 2, description = "Draws attention to a new or important feature.")
+@Composable
+fun TeachingTipScreen() {
+    GalleryPage(
+        title = "TeachingTip",
+        description = "A TeachingTip is a rich flyout that can teach users about a feature. " +
+                "It can point to an anchor or open by itself in the center of the window.",
+        componentPath = FluentSourceFile.TeachingTip,
+        galleryPath = ComponentPagePath.TeachingTipScreen,
+    ) {
+        var showIcon by remember { mutableStateOf(true) }
+        var showHero by remember { mutableStateOf(true) }
+        var showAction by remember { mutableStateOf(true) }
+        var showSecondaryAction by remember { mutableStateOf(true) }
+        var showCloseAction by remember { mutableStateOf(true) }
+        Section(
+            title = "A teaching tip with configurable slots.",
+            sourceCode = sourceCodeOfConfigurableTeachingTipSlotsSample,
+            content = {
+                ConfigurableTeachingTipSlotsSample(
+                    showIcon = showIcon,
+                    showHero = showHero,
+                    showAction = showAction,
+                    showSecondaryAction = showSecondaryAction,
+                    showCloseAction = showCloseAction,
+                )
+            },
+            options = {
+                CheckBox(
+                    checked = showIcon,
+                    onCheckStateChange = { showIcon = it },
+                    label = "Show icon",
+                )
+                CheckBox(
+                    checked = showHero,
+                    onCheckStateChange = { showHero = it },
+                    label = "Show hero",
+                )
+                CheckBox(
+                    checked = showAction,
+                    onCheckStateChange = { showAction = it },
+                    label = "Show action",
+                )
+                CheckBox(
+                    checked = showSecondaryAction,
+                    onCheckStateChange = { showSecondaryAction = it },
+                    label = "Show secondary action",
+                )
+                CheckBox(
+                    checked = showCloseAction,
+                    onCheckStateChange = { showCloseAction = it },
+                    label = "Show close action",
+                )
+            },
+        )
+        Section(
+            title = "A targeted teaching tip with hero content.",
+            sourceCode = sourceCodeOfTargetedTeachingTipSample,
+            content = { TargetedTeachingTipSample() },
+        )
+        Section(
+            title = "Multiple teaching tips targeting one image.",
+            sourceCode = sourceCodeOfMultipleImageTeachingTipsSample,
+            content = { MultipleImageTeachingTipsSample() },
+        )
+        Section(
+            title = "A preferred placement that falls back when space is unavailable.",
+            sourceCode = sourceCodeOfAdaptiveTeachingTipSample,
+            content = { AdaptiveTeachingTipSample() },
+        )
+        Section(
+            title = "A teaching tip without an anchor.",
+            sourceCode = sourceCodeOfCenteredTeachingTipSample,
+            content = { CenteredTeachingTipSample() },
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun ConfigurableTeachingTipSlotsSample(
+    showIcon: Boolean,
+    showHero: Boolean,
+    showAction: Boolean,
+    showSecondaryAction: Boolean,
+    showCloseAction: Boolean,
+) {
+    TeachingTipContainer(
+        teachingTip = {
+            TeachingTip(
+                title = { Text("Inspect the layout") },
+                placement = FlyoutPlacement.Bottom,
+                icon = if (showIcon) {
+                    {
+                        Icon(
+                            imageVector = Icons.Default.Lightbulb,
+                            contentDescription = null,
+                            tint = FluentTheme.colors.text.text.primary,
+                            modifier = Modifier.size(TeachingTipDefaults.IconSize),
+                        )
+                    }
+                } else {
+                    null
+                },
+                hero = if (showHero) {
+                    {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(96.dp)
+                                .background(FluentTheme.colors.fillAccent.default),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "Hero",
+                                color = FluentTheme.colors.text.onAccent.primary,
+                            )
+                        }
+                    }
+                } else {
+                    null
+                },
+                action = if (showAction) {
+                    {
+                        Button(
+                            onClick = { isTeachingTipVisible = false },
+                            content = { Text("Primary") },
+                        )
+                    }
+                } else {
+                    null
+                },
+                secondaryAction = if (showSecondaryAction) {
+                    {
+                        Button(
+                            onClick = {},
+                            content = { Text("Secondary") },
+                        )
+                    }
+                } else {
+                    null
+                },
+                closeAction = if (showCloseAction) {
+                    {
+                        TeachingTipDefaults.CloseButton(
+                            onClick = { isTeachingTipVisible = false },
+                            contentDescription = "Close",
+                        )
+                    }
+                } else {
+                    null
+                },
+                focusable = false,
+                content = {
+                    Text("Toggle the optional slots to inspect their spacing and alignment.")
+                },
+            )
+        },
+        content = {
+            Button(
+                onClick = { isTeachingTipVisible = !isTeachingTipVisible },
+                content = { Text("Show configurable tip") },
+            )
+        },
+    )
+}
+
+@Sample
+@Composable
+private fun TargetedTeachingTipSample() {
+    TeachingTipContainer(
+        teachingTip = {
+            TeachingTip(
+                title = { Text("Create faster with suggestions") },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.Lightbulb,
+                        contentDescription = null,
+                        tint = FluentTheme.colors.text.text.primary,
+                        modifier = Modifier.size(TeachingTipDefaults.IconSize)
+                    )
+                },
+                placement = FlyoutPlacement.Bottom,
+                hero = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(112.dp)
+                            .background(FluentTheme.colors.fillAccent.default),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Lightbulb,
+                            contentDescription = null,
+                            modifier = Modifier.size(44.dp),
+                            tint = FluentTheme.colors.text.onAccent.primary,
+                        )
+                    }
+                },
+                action = {
+                    Button(
+                        onClick = { isTeachingTipVisible = false },
+                        content = { Text("Try it") }
+                    )
+                },
+                closeAction = {
+                    TeachingTipDefaults.CloseButton(
+                        onClick = { isTeachingTipVisible = false },
+                        contentDescription = "Close",
+                    )
+                },
+                content = { Text("Suggestions appear while you work and stay out of the way when you do not need them.") }
+            )
+        },
+        content = {
+            Button(
+                onClick = { isTeachingTipVisible = !isTeachingTipVisible },
+                content = { Text("Show teaching tip") }
+            )
+        },
+    )
+}
+
+@Sample
+@Composable
+private fun MultipleImageTeachingTipsSample() {
+    var imageBounds by remember { mutableStateOf<Rect?>(null) }
+    var firstVisible by remember { mutableStateOf(false) }
+    var secondVisible by remember { mutableStateOf(false) }
+    val firstTarget = imageBounds?.let { bounds ->
+        Rect(
+            left = bounds.left + bounds.width * 0.2f,
+            top = bounds.top + bounds.height * 0.18f,
+            right = bounds.left + bounds.width * 0.3f,
+            bottom = bounds.top + bounds.height * 0.34f,
+        )
+    }
+    val secondTarget = imageBounds?.let { bounds ->
+        Rect(
+            left = bounds.left + bounds.width * 0.7f,
+            top = bounds.top + bounds.height * 0.66f,
+            right = bounds.left + bounds.width * 0.8f,
+            bottom = bounds.top + bounds.height * 0.82f,
+        )
+    }
+
+    Box {
+        Box(
+            modifier = Modifier
+                .size(320.dp, 200.dp)
+                .onGloballyPositioned { imageBounds = it.boundsInWindow() },
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.banner),
+                contentDescription = "Image with multiple teaching tip targets",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.matchParentSize(),
+            )
+            TeachingTipMarker(
+                label = "1",
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(x = 64.dp, y = 36.dp)
+                    .clickable { firstVisible = !firstVisible },
+            )
+            TeachingTipMarker(
+                label = "2",
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .offset(x = (-64).dp, y = (-36).dp)
+                    .clickable { secondVisible = !secondVisible },
+            )
+        }
+        TeachingTip(
+            visible = firstVisible && firstTarget != null,
+            onDismissRequest = { firstVisible = false },
+            target = firstTarget,
+            placement = FlyoutPlacement.Bottom,
+            title = { Text("Image detail") },
+            content = { Text("This tip points to the first region of the image.") }
+        )
+        TeachingTip(
+            visible = secondVisible && secondTarget != null,
+            onDismissRequest = { secondVisible = false },
+            target = secondTarget,
+            placement = FlyoutPlacement.Top,
+            title = { Text("Another detail") },
+            content = { Text("A second tip can use another Rect from the same image.") }
+        )
+    }
+}
+
+@Composable
+private fun TeachingTipMarker(
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        content = { Text(label, color = FluentTheme.colors.text.onAccent.primary) },
+        modifier = modifier
+            .size(32.dp)
+            .background(FluentTheme.colors.fillAccent.default, CircleShape),
+    )
+}
+
+@Sample
+@Composable
+private fun AdaptiveTeachingTipSample() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(64.dp),
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        TeachingTipContainer(
+            teachingTip = {
+                TeachingTip(
+                    title = { Text("Placement adjusted") },
+                    placement = FlyoutPlacement.End,
+                    closeAction = {
+                        TeachingTipDefaults.CloseButton(
+                            onClick = { isTeachingTipVisible = false },
+                            contentDescription = "Close",
+                        )
+                    },
+                    content = { Text("The preferred end placement is used only when enough window space is available.") }
+                )
+            },
+            content = {
+                Button(
+                    onClick = { isTeachingTipVisible = !isTeachingTipVisible },
+                    content = { Text("Show at edge") }
+                )
+            },
+        )
+    }
+}
+
+@Sample
+@Composable
+private fun CenteredTeachingTipSample() {
+    var visible by remember { mutableStateOf(false) }
+    TeachingTip(
+        visible = visible,
+        onDismissRequest = { visible = false },
+        title = { Text("Welcome to the gallery") },
+        target = null,
+        action = {
+            Button(
+                onClick = { visible = false },
+                content =  { Text("Get started") }
+            )
+        },
+        closeAction = {
+            TeachingTipDefaults.CloseButton(
+                onClick = { visible = false },
+                contentDescription = "Close",
+            )
+        },
+        content = { Text("This teaching tip has no anchor, so it opens from the center of the window.") }
+    )
+
+    Button(
+        onClick = { visible = true },
+        content = { Text("Show centered tip") }
+    )
+}


### PR DESCRIPTION
## Summary

- Add a `TeachingTip` component with both window-coordinate `Rect` targets and a scoped `TeachingTipContainer` API.
- Resolve preferred placement adaptively, keep the tail on the edge nearest the target, and animate from the tail vertex with Fluent motion curves.
- Support hero, icon, title, content, close, and up to two equal-width action slots using the Fluent TeachingTip layout and solid surface styling.
- Let internal Flyout surfaces accept custom colors, stroke colors, and Acrylic behavior, while preserving Acrylic defaults for existing callers.
- Keep NavigationView popup surfaces visible when global popup Acrylic is disabled.
- Add Gallery samples for configurable slots, container targets, multiple targets in one image, adaptive placement, and centered tips.
- Document the public TeachingTip APIs and their visibility, targeting, placement, and slot contracts.

## Motivation

Teaching tips need to point at either a complete composable or an arbitrary region such as one of several areas inside an image. The existing Flyout surface path owned its Acrylic styling internally, so TeachingTip could not select the solid tertiary background and default surface border required by the Fluent design.

NavigationView popup layers also remained transparent when popup Acrylic was disabled. This change provides a solid-color fallback while keeping existing Acrylic behavior unchanged when enabled.

## User impact

Consumers can present Fluent TeachingTips with adaptive positioning and optional rich content without wrapping every target in a dedicated composable. Existing Flyout callers retain their current defaults.

## Validation

- `./gradlew :gallery:sharedApp:compileKotlinJvm --no-configuration-cache --no-daemon` — BUILD SUCCESSFUL
- `git diff origin/dev...HEAD --check`
- Tests were not run because this repository requires explicit authorization before running them.
